### PR TITLE
Add technology parameter to filter copied files

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,13 @@ The `dynatrace-bootstrapper` is a small CLI binary built into a [Dynatrace CodeM
 - This is an **optional** arg
 - The `--work` arg defines the base path for a tmp folder, this is where the command will do its work, to make sure the operations are atomic. It must be on the same disk as the target folder.
 
+#### `--technology`
+
+*Example*: `--technology="python,java"`
+
+- This is an **optional** arg
+- The `--technology` arg defines the paths associated to the given technology in the `manifest.json` file. Only those files will be copied that match the technology. It is a comma-separated list.
+
 ## Development
 
 - To run tests: `make test`

--- a/pkg/move/atomic.go
+++ b/pkg/move/atomic.go
@@ -1,0 +1,55 @@
+package move
+
+import (
+	"os"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/afero"
+)
+
+func atomic(copy copyFunc) copyFunc {
+	return func(fs afero.Afero) error {
+		logrus.Infof("Starting to copy (atomic) from %s to %s", sourceFolder, targetFolder)
+
+		err := fs.RemoveAll(workFolder)
+		if err != nil {
+			logrus.Errorf("Failed initial cleanup of workdir: %v", err)
+
+			return err
+		}
+
+		err = fs.MkdirAll(workFolder, os.ModePerm)
+		if err != nil {
+			logrus.Errorf("Failed to create the base workdir: %v", err)
+
+			return err
+		}
+
+		defer func() {
+			err := fs.RemoveAll(workFolder)
+			if err != nil {
+				logrus.Errorf("Failed to do cleanup after run: %v", err)
+			}
+		}()
+
+		//tmpFolder := filepath.Join(workFolder, copyTmpFolder)
+
+		err = copy(fs)
+		if err != nil {
+			logrus.Errorf("Error moving folder: %v", err)
+
+			return err
+		}
+
+		//err = fs.Rename(tmpFolder, targetFolder)
+		//if err != nil {
+		//	logrus.Errorf("Error finalizing move: %v", err)
+
+		//			return err
+		//		}
+
+		logrus.Infof("Successfully copied from %s to %s", sourceFolder, targetFolder)
+
+		return nil
+	}
+}

--- a/pkg/move/atomic.go
+++ b/pkg/move/atomic.go
@@ -32,21 +32,12 @@ func atomic(copy copyFunc) copyFunc {
 			}
 		}()
 
-		//tmpFolder := filepath.Join(workFolder, copyTmpFolder)
-
 		err = copy(fs)
 		if err != nil {
 			logrus.Errorf("Error moving folder: %v", err)
 
 			return err
 		}
-
-		//err = fs.Rename(tmpFolder, targetFolder)
-		//if err != nil {
-		//	logrus.Errorf("Error finalizing move: %v", err)
-
-		//			return err
-		//		}
 
 		logrus.Infof("Successfully copied from %s to %s", sourceFolder, targetFolder)
 

--- a/pkg/move/atomic_test.go
+++ b/pkg/move/atomic_test.go
@@ -8,48 +8,51 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const tmpWorkFolder = "/work/tmp"
+
 func mockCopyFunc(isSuccessful bool) copyFunc {
 	return func(fs afero.Afero) error {
 		if isSuccessful {
-			fs.MkdirAll("/work/tmp", 0755) //nolint:errcheck
+			_ = fs.MkdirAll(tmpWorkFolder, 0755)
 			return nil
 		}
 
 		return errors.New("some mock error")
 	}
 }
-func TestAtomic_NoError(t *testing.T) {
-	fs := afero.Afero{Fs: afero.NewMemMapFs()}
-	sourceFolder = "/source"
-	targetFolder = "/target"
-	workFolder = "/work"
+func TestAtomic(t *testing.T) {
+	t.Run("success -> targetFolder is present", func(t *testing.T) {
+		fs := afero.Afero{Fs: afero.NewMemMapFs()}
+		sourceFolder = "/source"
+		targetFolder = "/target"
+		workFolder = "/work"
 
-	err := fs.MkdirAll(sourceFolder, 0755)
-	assert.NoError(t, err)
+		err := fs.MkdirAll(sourceFolder, 0755)
+		assert.NoError(t, err)
 
-	atomicCopy := atomic(mockCopyFunc(true))
+		atomicCopy := atomic(mockCopyFunc(true))
 
-	err = atomicCopy(fs)
-	assert.NoError(t, err)
+		err = atomicCopy(fs)
+		assert.NoError(t, err)
 
-	exists, err := fs.DirExists(workFolder)
-	assert.NoError(t, err)
-	assert.False(t, exists)
-}
+		exists, err := fs.DirExists(workFolder)
+		assert.NoError(t, err)
+		assert.False(t, exists)
+	})
+	t.Run("fail -> targetFolder is not present", func(t *testing.T) {
+		fs := afero.Afero{Fs: afero.NewMemMapFs()}
+		sourceFolder = "/source"
+		targetFolder = "/target"
+		workFolder = "/work"
 
-func TestAtomic_Error(t *testing.T) {
-	fs := afero.Afero{Fs: afero.NewMemMapFs()}
-	sourceFolder = "/source"
-	targetFolder = "/target"
-	workFolder = "/work"
+		atomicCopy := atomic(mockCopyFunc(false))
 
-	atomicCopy := atomic(mockCopyFunc(false))
+		err := atomicCopy(fs)
+		assert.Error(t, err)
+		assert.Equal(t, "some mock error", err.Error())
 
-	err := atomicCopy(fs)
-	assert.Error(t, err)
-	assert.Equal(t, "some mock error", err.Error())
-
-	exists, err := fs.DirExists(workFolder)
-	assert.NoError(t, err)
-	assert.False(t, exists)
+		exists, err := fs.DirExists(workFolder)
+		assert.NoError(t, err)
+		assert.False(t, exists)
+	})
 }

--- a/pkg/move/atomic_test.go
+++ b/pkg/move/atomic_test.go
@@ -1,0 +1,54 @@
+package move
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+)
+
+func mockCopyFunc(isSuccessful bool) copyFunc {
+	return func(fs afero.Afero) error {
+		if isSuccessful {
+			fs.MkdirAll("/work/tmp", 0755)
+			return nil
+		}
+
+		return errors.New("some mock error")
+	}
+}
+func TestAtomic_NoError(t *testing.T) {
+	fs := afero.Afero{Fs: afero.NewMemMapFs()}
+	sourceFolder = "/source"
+	targetFolder = "/target"
+	workFolder = "/work"
+
+	fs.MkdirAll(sourceFolder, 0755)
+
+	atomicCopy := atomic(mockCopyFunc(true))
+
+	err := atomicCopy(fs)
+	assert.NoError(t, err)
+
+	exists, err := fs.DirExists(workFolder)
+	assert.NoError(t, err)
+	assert.False(t, exists)
+}
+
+func TestAtomic_Error(t *testing.T) {
+	fs := afero.Afero{Fs: afero.NewMemMapFs()}
+	sourceFolder = "/source"
+	targetFolder = "/target"
+	workFolder = "/work"
+
+	atomicCopy := atomic(mockCopyFunc(false))
+
+	err := atomicCopy(fs)
+	assert.Error(t, err)
+	assert.Equal(t, "some mock error", err.Error())
+
+	exists, err := fs.DirExists(workFolder)
+	assert.NoError(t, err)
+	assert.False(t, exists)
+}

--- a/pkg/move/atomic_test.go
+++ b/pkg/move/atomic_test.go
@@ -11,7 +11,7 @@ import (
 func mockCopyFunc(isSuccessful bool) copyFunc {
 	return func(fs afero.Afero) error {
 		if isSuccessful {
-			fs.MkdirAll("/work/tmp", 0755)
+			fs.MkdirAll("/work/tmp", 0755) //nolint:errcheck
 			return nil
 		}
 
@@ -24,11 +24,12 @@ func TestAtomic_NoError(t *testing.T) {
 	targetFolder = "/target"
 	workFolder = "/work"
 
-	fs.MkdirAll(sourceFolder, 0755)
+	err := fs.MkdirAll(sourceFolder, 0755)
+	assert.NoError(t, err)
 
 	atomicCopy := atomic(mockCopyFunc(true))
 
-	err := atomicCopy(fs)
+	err = atomicCopy(fs)
 	assert.NoError(t, err)
 
 	exists, err := fs.DirExists(workFolder)

--- a/pkg/move/cmd.go
+++ b/pkg/move/cmd.go
@@ -1,14 +1,6 @@
 package move
 
 import (
-	"encoding/json"
-	"io"
-	"os"
-	"path/filepath"
-	"strings"
-
-	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
@@ -29,17 +21,6 @@ var (
 	technology   string
 )
 
-type Manifest struct {
-	Technologies map[string]map[string][]FileEntry `json:"technologies"`
-	Version      string                            `json:"version"`
-}
-
-type FileEntry struct {
-	Path    string `json:"path"`
-	Version string `json:"version"`
-	MD5     string `json:"md5"`
-}
-
 func AddFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringVar(&sourceFolder, sourceFolderFlag, "", "Base path where to copy the codemodule FROM.")
 	_ = cmd.MarkPersistentFlagRequired(sourceFolderFlag)
@@ -56,204 +37,15 @@ func AddFlags(cmd *cobra.Command) {
 // Execute moves the contents of a folder to another via copying.
 // This could be a simple os.Rename, however that will not work if the source and target are on different disk.
 func Execute(fs afero.Afero) error {
-	if workFolder != "" {
-		return atomicCopy(fs)
-	}
-
-	return simpleCopy(fs)
-}
-
-func atomicCopy(fs afero.Afero) error {
-	logrus.Infof("Starting to copy (atomic) from %s to %s", sourceFolder, targetFolder)
-
-	err := fs.RemoveAll(workFolder)
-	if err != nil {
-		logrus.Errorf("Failed initial cleanup of workdir: %v", err)
-
-		return err
-	}
-
-	err = fs.MkdirAll(workFolder, os.ModePerm)
-	if err != nil {
-		logrus.Errorf("Failed to create the base workdir: %v", err)
-
-		return err
-	}
-
-	defer func() {
-		err := fs.RemoveAll(workFolder)
-		if err != nil {
-			logrus.Errorf("Failed to do cleanup after run: %v", err)
-		}
-	}()
-
-	tmpFolder := filepath.Join(workFolder, copyTmpFolder)
-
-	err = copyFolder(fs, sourceFolder, tmpFolder)
-	if err != nil {
-		logrus.Errorf("Error moving folder: %v", err)
-
-		return err
-	}
-
-	err = fs.Rename(tmpFolder, targetFolder)
-	if err != nil {
-		logrus.Errorf("Error finalizing move: %v", err)
-
-		return err
-	}
-
-	logrus.Infof("Successfully copied from %s to %s", sourceFolder, targetFolder)
-
-	return nil
-}
-
-func simpleCopy(fs afero.Afero) error {
-	logrus.Infof("Starting to copy (simple) from %s to %s", sourceFolder, targetFolder)
-
-	err := copyFolder(fs, sourceFolder, targetFolder)
-	if err != nil {
-		logrus.Errorf("Error moving folder: %v", err)
-
-		return err
-	}
-
-	logrus.Infof("Successfully copied from %s to %s", sourceFolder, targetFolder)
-
-	return nil
-}
-
-func filterFilesByTechnology(fs afero.Afero, source string, technologies []string) ([]string, error) {
-	manifestPath := filepath.Join(source, "manifest.json")
-
-	manifestFile, err := fs.ReadFile(manifestPath)
-	if err != nil {
-		return nil, errors.WithMessage(err, "failed to open manifest.json")
-	}
-
-	var manifest Manifest
-	if err := json.Unmarshal(manifestFile, &manifest); err != nil {
-		return nil, errors.WithMessage(err, "failed to parse manifest.json")
-	}
-
-	var paths []string
-
-	for _, tech := range technologies {
-		techData, exists := manifest.Technologies[tech]
-		if !exists {
-			logrus.Warnf("technology %s not found", tech)
-			continue
-		}
-
-		for _, files := range techData {
-			logrus.Infof("processing technology %s", tech)
-
-			for _, file := range files {
-				paths = append(paths, filepath.Join(source, file.Path))
-			}
-		}
-	}
-
-	return paths, nil
-}
-
-func copyFolder(fs afero.Fs, from string, to string) error {
-	fromInfo, err := fs.Stat(from)
-	if err != nil {
-		return errors.WithStack(err)
-	}
-
-	if !fromInfo.IsDir() {
-		return errors.Errorf("%s is not a directory", from)
-	}
-
-	err = fs.MkdirAll(to, fromInfo.Mode())
-	if err != nil {
-		return errors.WithStack(err)
-	}
-
-	var filteredPaths []string
+	copy := simpleCopy
 
 	if technology != "" {
-		var err error
-
-		filteredPaths, err = filterFilesByTechnology(afero.Afero{Fs: fs}, sourceFolder, strings.Split(technology, ","))
-		if err != nil {
-			return err
-		}
+		copy = copyByTechnology
 	}
 
-	entries, err := afero.ReadDir(fs, from)
-	if err != nil {
-		return errors.WithStack(err)
+	if workFolder != "" {
+		copy = atomic(copy)
 	}
 
-	for _, entry := range entries {
-		toPath := filepath.Join(from, entry.Name())
-		fromPath := filepath.Join(to, entry.Name())
-
-		if entry.IsDir() {
-			if len(filteredPaths) == 0 {
-				logrus.Infof("Copying directory %s to %s", toPath, fromPath)
-
-				err = copyFolder(fs, toPath, fromPath)
-				if err != nil {
-					return err
-				}
-			}
-		} else {
-			if len(filteredPaths) == 0 || contains(filteredPaths, strings.Split(fromPath, to)[1]) {
-				logrus.Infof("Copying file %s to %s", toPath, fromPath)
-
-				err = copyFile(fs, toPath, fromPath)
-				if err != nil {
-					return err
-				}
-			}
-		}
-	}
-
-	return nil
-}
-
-func copyFile(fs afero.Fs, sourcePath string, destinationPath string) error {
-	sourceFile, err := fs.Open(sourcePath)
-	if err != nil {
-		return errors.WithStack(err)
-	}
-	defer sourceFile.Close()
-
-	sourceInfo, err := sourceFile.Stat()
-	if err != nil {
-		return errors.WithStack(err)
-	}
-
-	destinationFile, err := fs.OpenFile(destinationPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, sourceInfo.Mode())
-	if err != nil {
-		return errors.WithStack(err)
-	}
-
-	defer destinationFile.Close()
-
-	_, err = io.Copy(destinationFile, sourceFile)
-	if err != nil {
-		return errors.WithStack(err)
-	}
-
-	err = destinationFile.Sync()
-	if err != nil {
-		return errors.WithStack(err)
-	}
-
-	return nil
-}
-
-func contains(slice []string, item string) bool {
-	for _, s := range slice {
-		if strings.Contains(s, item) {
-			return true
-		}
-	}
-
-	return false
+	return copy(fs)
 }

--- a/pkg/move/cmd.go
+++ b/pkg/move/cmd.go
@@ -10,8 +10,6 @@ const (
 	targetFolderFlag = "target"
 	workFolderFlag   = "work"
 	technologyFlag   = "technology"
-
-	copyTmpFolder = "copy-tmp"
 )
 
 var (

--- a/pkg/move/cmd_test.go
+++ b/pkg/move/cmd_test.go
@@ -1,6 +1,7 @@
 package move
 
 import (
+	"fmt"
 	"path/filepath"
 	"testing"
 
@@ -86,6 +87,144 @@ func TestCopyFolder(t *testing.T) {
 	require.Len(t, dstFiles, len(srcFiles))
 
 	checkFolder(t, fs, src, dst)
+}
+
+func TestCopyFolderWithTechnologyFiltering(t *testing.T) {
+	fs := afero.Afero{Fs: afero.NewMemMapFs()}
+
+	sourceDir := "/source"
+	targetDir := "/target"
+
+	sourceFolder = sourceDir
+	targetFolder = targetDir
+
+	_ = fs.MkdirAll(sourceDir, 0755)
+	_ = fs.MkdirAll(targetDir, 0755)
+
+	manifestContent := `{
+        "version": "1.0",
+        "technologies": {
+            "java": {
+                "x86": [
+                    {"path": "fileA1.txt", "version": "1.0", "md5": "abc123"},
+                    {"path": "fileA2.txt", "version": "1.0", "md5": "def456"}
+                ]
+            },
+            "python": {
+                "arm": [
+                    {"path": "fileB1.txt", "version": "1.0", "md5": "ghi789"}
+                ]
+            }
+        }
+    }`
+
+	_ = afero.WriteFile(fs, filepath.Join(sourceDir, "manifest.json"), []byte(manifestContent), 0644)
+	_ = afero.WriteFile(fs, filepath.Join(sourceDir, "fileA1.txt"), []byte("java a1"), 0644)
+	_ = afero.WriteFile(fs, filepath.Join(sourceDir, "fileA2.txt"), []byte("java a2"), 0644)
+	_ = afero.WriteFile(fs, filepath.Join(sourceDir, "fileB1.txt"), []byte("python b1"), 0644)
+	_ = afero.WriteFile(fs, filepath.Join(sourceDir, "fileC1.txt"), []byte("unrelated"), 0644)
+
+	t.Run("copy with single technology filter", func(t *testing.T) {
+		technology = "java"
+		err := copyFolder(fs, sourceDir, targetDir)
+		require.NoError(t, err)
+
+		assertFileExists(t, fs, filepath.Join(targetDir, "fileA1.txt"))
+		assertFileExists(t, fs, filepath.Join(targetDir, "fileA2.txt"))
+		assertFileNotExists(t, fs, filepath.Join(targetDir, "fileB1.txt"))
+		assertFileNotExists(t, fs, filepath.Join(targetDir, "fileC1.txt"))
+	})
+	t.Run("copy with multiple technology filter", func(t *testing.T) {
+		technology = "java,python"
+		err := copyFolder(fs, sourceDir, targetDir)
+		require.NoError(t, err)
+
+		assertFileExists(t, fs, filepath.Join(targetDir, "fileA1.txt"))
+		assertFileExists(t, fs, filepath.Join(targetDir, "fileA2.txt"))
+		assertFileExists(t, fs, filepath.Join(targetDir, "fileB1.txt"))
+		assertFileNotExists(t, fs, filepath.Join(targetDir, "fileC1.txt"))
+	})
+	t.Run("copy with invalid technology filter", func(t *testing.T) {
+		technology = "php"
+		err := copyFolder(fs, sourceDir, targetDir)
+		require.NoError(t, err)
+
+		assertFileExists(t, fs, filepath.Join(targetDir, "fileA1.txt"))
+		assertFileExists(t, fs, filepath.Join(targetDir, "fileA2.txt"))
+		assertFileExists(t, fs, filepath.Join(targetDir, "fileB1.txt"))
+		assertFileExists(t, fs, filepath.Join(targetDir, "fileC1.txt"))
+	})
+}
+
+func assertFileExists(t *testing.T, fs afero.Fs, path string) {
+	t.Helper()
+
+	exists, err := afero.Exists(fs, path)
+	assert.NoError(t, err)
+	assert.True(t, exists, fmt.Sprintf("file should exist: %s", path))
+}
+func assertFileNotExists(t *testing.T, fs afero.Fs, path string) {
+	t.Helper()
+
+	exists, err := afero.Exists(fs, path)
+	assert.NoError(t, err)
+	assert.False(t, exists, fmt.Sprintf("file should not exist: %s", path))
+}
+
+func TestFilterFilesByTechnology(t *testing.T) {
+	fs := afero.Afero{Fs: afero.NewMemMapFs()}
+
+	sourceDir := "/source"
+	_ = fs.MkdirAll(sourceDir, 0755)
+	manifestContent := `{
+        "version": "1.0",
+        "technologies": {
+            "java": {
+                "x86": [
+                    {"path": "fileA1.txt", "version": "1.0", "md5": "abc123"},
+                    {"path": "fileA2.txt", "version": "1.0", "md5": "def456"}
+                ]
+            },
+            "python": {
+                "arm": [
+                    {"path": "fileB1.txt", "version": "1.0", "md5": "ghi789"}
+                ]
+            }
+        }
+    }`
+	_ = afero.WriteFile(fs, filepath.Join(sourceDir, "manifest.json"), []byte(manifestContent), 0644)
+	_ = afero.WriteFile(fs, filepath.Join(sourceDir, "fileA1.txt"), []byte("a1 content"), 0644)
+	_ = afero.WriteFile(fs, filepath.Join(sourceDir, "fileA2.txt"), []byte("a2 content"), 0644)
+	_ = afero.WriteFile(fs, filepath.Join(sourceDir, "fileB1.txt"), []byte("b1 content"), 0644)
+
+	t.Run("filter single technology", func(t *testing.T) {
+		paths, err := filterFilesByTechnology(fs, sourceDir, []string{"java"})
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{
+			filepath.Join(sourceDir, "fileA1.txt"),
+			filepath.Join(sourceDir, "fileA2.txt"),
+		}, paths)
+	})
+	t.Run("filter multiple technologies", func(t *testing.T) {
+		paths, err := filterFilesByTechnology(fs, sourceDir, []string{"java", "python"})
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{
+			filepath.Join(sourceDir, "fileA1.txt"),
+			filepath.Join(sourceDir, "fileA2.txt"),
+			filepath.Join(sourceDir, "fileB1.txt"),
+		}, paths)
+	})
+	t.Run("not filter non-existing technology", func(t *testing.T) {
+		paths, err := filterFilesByTechnology(fs, sourceDir, []string{"php"})
+		require.NoError(t, err)
+		assert.Empty(t, paths)
+	})
+	t.Run("filter with missing manifest", func(t *testing.T) {
+		fs := afero.Afero{Fs: afero.NewMemMapFs()}
+		paths, err := filterFilesByTechnology(fs, sourceDir, []string{"java"})
+		require.Error(t, err)
+		assert.Nil(t, paths)
+	})
 }
 
 func checkFolder(t *testing.T, fs afero.Fs, src, dst string) {

--- a/pkg/move/copy.go
+++ b/pkg/move/copy.go
@@ -1,0 +1,104 @@
+package move
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/afero"
+)
+
+type copyFunc func(fs afero.Afero) error
+
+func simpleCopy(fs afero.Afero) error {
+	logrus.Infof("Starting to copy (simple) from %s to %s", sourceFolder, targetFolder)
+
+	err := copyFolder(fs, sourceFolder, targetFolder)
+	if err != nil {
+		logrus.Errorf("Error moving folder: %v", err)
+
+		return err
+	}
+
+	logrus.Infof("Successfully copied from %s to %s", sourceFolder, targetFolder)
+
+	return nil
+}
+
+func copyFolder(fs afero.Fs, from string, to string) error {
+	fromInfo, err := fs.Stat(from)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	if !fromInfo.IsDir() {
+		return errors.Errorf("%s is not a directory", from)
+	}
+
+	err = fs.MkdirAll(to, fromInfo.Mode())
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	entries, err := afero.ReadDir(fs, from)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	for _, entry := range entries {
+		toPath := filepath.Join(from, entry.Name())
+		fromPath := filepath.Join(to, entry.Name())
+
+		if entry.IsDir() {
+			logrus.Infof("Copying directory %s to %s", toPath, fromPath)
+
+			err = copyFolder(fs, toPath, fromPath)
+			if err != nil {
+				return err
+			}
+		} else {
+			logrus.Infof("Copying file %s to %s", toPath, fromPath)
+
+			err = copyFile(fs, toPath, fromPath)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func copyFile(fs afero.Fs, sourcePath string, destinationPath string) error {
+	sourceFile, err := fs.Open(sourcePath)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	defer sourceFile.Close()
+
+	sourceInfo, err := sourceFile.Stat()
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	destinationFile, err := fs.OpenFile(destinationPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, sourceInfo.Mode())
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	defer destinationFile.Close()
+
+	_, err = io.Copy(destinationFile, sourceFile)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	err = destinationFile.Sync()
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	return nil
+}

--- a/pkg/move/copy_test.go
+++ b/pkg/move/copy_test.go
@@ -1,0 +1,74 @@
+package move
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCopyFolder(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	src := "/src"
+	err := fs.MkdirAll(src, 0755)
+	require.NoError(t, err)
+
+	err = afero.WriteFile(fs, filepath.Join(src, "file1.txt"), []byte("Hello"), 0644)
+	require.NoError(t, err)
+
+	err = fs.MkdirAll(filepath.Join(src, "subdir"), 0755)
+	require.NoError(t, err)
+
+	err = afero.WriteFile(fs, filepath.Join(src, "subdir", "file2.txt"), []byte("World"), 0644)
+	require.NoError(t, err)
+
+	dst := "/dst"
+	err = fs.MkdirAll(dst, 0755)
+	require.NoError(t, err)
+
+	err = copyFolder(fs, src, dst)
+	require.NoError(t, err)
+
+	srcFiles, err := afero.ReadDir(fs, src)
+	require.NoError(t, err)
+	dstFiles, err := afero.ReadDir(fs, dst)
+	require.NoError(t, err)
+	require.Len(t, dstFiles, len(srcFiles))
+
+	checkFolder(t, fs, src, dst)
+}
+
+func TestCopyFile(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	source := "/source"
+	target := "/target"
+
+	err := fs.MkdirAll(source, 0755)
+	require.NoError(t, err)
+
+	err = afero.WriteFile(fs, filepath.Join(source, "file1.txt"), []byte("some content"), 0644)
+	require.NoError(t, err)
+
+	err = fs.MkdirAll(target, 0755)
+	require.NoError(t, err)
+
+	err = copyFile(fs, filepath.Join(source, "file1.txt"), filepath.Join(target, "file1.txt"))
+	require.NoError(t, err)
+
+	sourceContent, err := afero.ReadFile(fs, filepath.Join(source, "file1.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "some content", string(sourceContent))
+
+	targetContent, err := afero.ReadFile(fs, filepath.Join(source, "file1.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "some content", string(targetContent))
+
+	sourceFiles, err := afero.ReadDir(fs, source)
+	require.NoError(t, err)
+
+	targetFiles, err := afero.ReadDir(fs, target)
+	require.NoError(t, err)
+	require.Len(t, targetFiles, len(sourceFiles))
+}

--- a/pkg/move/technologies.go
+++ b/pkg/move/technologies.go
@@ -1,0 +1,84 @@
+package move
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/afero"
+)
+
+type Manifest struct {
+	Technologies TechEntries `json:"technologies"`
+	Version      string      `json:"version"`
+}
+
+type TechEntries map[string]ArchEntries
+type ArchEntries map[string][]FileEntry
+
+type FileEntry struct {
+	Path    string `json:"path"`
+	Version string `json:"version"`
+	MD5     string `json:"md5"`
+}
+
+func copyByTechnology(fs afero.Afero) error {
+	logrus.Infof("Starting to copy (filtered) from %s to %s", sourceFolder, targetFolder)
+
+	filteredPaths, err := filterFilesByTechnology(fs, sourceFolder, strings.Split(technology, ","))
+	if err != nil {
+		return err
+	}
+
+	for _, path := range filteredPaths {
+		targetFile := filepath.Join(targetFolder, strings.Split(path, sourceFolder)[1])
+
+		err = fs.MkdirAll(filepath.Dir(targetFile), os.ModePerm) // check source dir's Stat.Mode
+		err = copyFile(fs, path, targetFile)
+
+		if err != nil {
+			logrus.Errorf("Error moving folder: %v", err)
+
+			return err
+		}
+	}
+
+	return nil
+}
+
+func filterFilesByTechnology(fs afero.Afero, source string, technologies []string) ([]string, error) {
+	manifestPath := filepath.Join(source, "manifest.json")
+
+	manifestFile, err := fs.ReadFile(manifestPath)
+	if err != nil {
+		return nil, errors.WithMessage(err, "failed to open manifest.json")
+	}
+
+	var manifest Manifest
+	if err := json.Unmarshal(manifestFile, &manifest); err != nil {
+		return nil, errors.WithMessage(err, "failed to parse manifest.json")
+	}
+
+	var paths []string
+
+	for _, tech := range technologies {
+		techData, exists := manifest.Technologies[tech]
+		if !exists {
+			logrus.Warnf("technology %s not found", tech)
+			continue
+		}
+
+		for _, files := range techData {
+			logrus.Infof("processing technology %s", tech)
+
+			for _, file := range files {
+				paths = append(paths, filepath.Join(source, file.Path))
+			}
+		}
+	}
+
+	return paths, nil
+}

--- a/pkg/move/technologies.go
+++ b/pkg/move/technologies.go
@@ -2,7 +2,6 @@ package move
 
 import (
 	"encoding/json"
-	"os"
 	"path/filepath"
 	"strings"
 
@@ -36,7 +35,14 @@ func copyByTechnology(fs afero.Afero) error {
 	for _, path := range filteredPaths {
 		targetFile := filepath.Join(targetFolder, strings.Split(path, sourceFolder)[1])
 
-		err = fs.MkdirAll(filepath.Dir(targetFile), os.ModePerm) // check source dir's Stat.Mode
+		sourceStatMode, err := fs.Stat(sourceFolder)
+		if err != nil {
+			logrus.Errorf("Error checking stat mode from source folder: %v", err)
+
+			return err
+		}
+
+		err = fs.MkdirAll(filepath.Dir(targetFile), sourceStatMode.Mode()) //TODO: check source dir's Stat.Mode
 		if err != nil {
 			logrus.Errorf("Error checking folder: %v", err)
 

--- a/pkg/move/technologies.go
+++ b/pkg/move/technologies.go
@@ -80,12 +80,12 @@ func filterFilesByTechnology(fs afero.Afero, source string, technologies []strin
 	for _, tech := range technologies {
 		techData, exists := manifest.Technologies[tech]
 		if !exists {
-			logrus.Warnf("technology %s not found", tech)
+			logrus.Warnf("Technology %s not found", tech)
 			continue
 		}
 
-		for _, files := range techData {
-			logrus.Infof("processing technology %s", tech)
+		for arch, files := range techData {
+			logrus.Infof("Collecting files for technology %s for arch %s", tech, arch)
 
 			for _, file := range files {
 				paths = append(paths, filepath.Join(source, file.Path))

--- a/pkg/move/technologies.go
+++ b/pkg/move/technologies.go
@@ -42,7 +42,7 @@ func copyByTechnology(fs afero.Afero) error {
 			return err
 		}
 
-		err = fs.MkdirAll(filepath.Dir(targetFile), sourceStatMode.Mode()) //TODO: check source dir's Stat.Mode
+		err = fs.MkdirAll(filepath.Dir(targetFile), sourceStatMode.Mode())
 		if err != nil {
 			logrus.Errorf("Error checking folder: %v", err)
 

--- a/pkg/move/technologies.go
+++ b/pkg/move/technologies.go
@@ -37,6 +37,12 @@ func copyByTechnology(fs afero.Afero) error {
 		targetFile := filepath.Join(targetFolder, strings.Split(path, sourceFolder)[1])
 
 		err = fs.MkdirAll(filepath.Dir(targetFile), os.ModePerm) // check source dir's Stat.Mode
+		if err != nil {
+			logrus.Errorf("Error checking folder: %v", err)
+
+			return err
+		}
+
 		err = copyFile(fs, path, targetFile)
 
 		if err != nil {

--- a/pkg/move/technologies.go
+++ b/pkg/move/technologies.go
@@ -44,15 +44,16 @@ func copyByTechnology(fs afero.Afero) error {
 
 		err = fs.MkdirAll(filepath.Dir(targetFile), sourceStatMode.Mode())
 		if err != nil {
-			logrus.Errorf("Error checking folder: %v", err)
+			logrus.Errorf("Error creating target folder: %v", err)
 
 			return err
 		}
 
-		err = copyFile(fs, path, targetFile)
+		logrus.Infof("Copying file %s to %s", path, targetFile)
 
+		err = copyFile(fs, path, targetFile)
 		if err != nil {
-			logrus.Errorf("Error moving folder: %v", err)
+			logrus.Errorf("Error copying file: %v", err)
 
 			return err
 		}

--- a/pkg/move/technologies_test.go
+++ b/pkg/move/technologies_test.go
@@ -1,0 +1,148 @@
+package move
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCopyFolderWithTechnologyFiltering(t *testing.T) {
+	fs := afero.Afero{Fs: afero.NewMemMapFs()}
+
+	sourceDir := "/source"
+	targetDir := "/target"
+
+	sourceFolder = sourceDir
+	targetFolder = targetDir
+
+	_ = fs.MkdirAll(sourceDir, 0755)
+	_ = fs.MkdirAll(targetDir, 0755)
+
+	manifestContent := `{
+        "version": "1.0",
+        "technologies": {
+            "java": {
+                "x86": [
+                    {"path": "fileA1.txt", "version": "1.0", "md5": "abc123"},
+                    {"path": "fileA2.txt", "version": "1.0", "md5": "def456"}
+                ]
+            },
+            "python": {
+                "arm": [
+                    {"path": "fileB1.txt", "version": "1.0", "md5": "ghi789"}
+                ]
+            }
+        }
+    }`
+
+	_ = afero.WriteFile(fs, filepath.Join(sourceDir, "manifest.json"), []byte(manifestContent), 0644)
+	_ = afero.WriteFile(fs, filepath.Join(sourceDir, "fileA1.txt"), []byte("java a1"), 0644)
+	_ = afero.WriteFile(fs, filepath.Join(sourceDir, "fileA2.txt"), []byte("java a2"), 0644)
+	_ = afero.WriteFile(fs, filepath.Join(sourceDir, "fileB1.txt"), []byte("python b1"), 0644)
+	_ = afero.WriteFile(fs, filepath.Join(sourceDir, "fileC1.txt"), []byte("unrelated"), 0644)
+
+	t.Run("copy with single technology filter", func(t *testing.T) {
+		t.Cleanup(func() {
+			_ = fs.RemoveAll(targetDir)
+			_ = fs.MkdirAll(targetDir, 0755)
+		})
+
+		technology = "java"
+		err := copyByTechnology(fs)
+		require.NoError(t, err)
+
+		assertFileExists(t, fs, filepath.Join(targetDir, "fileA1.txt"))
+		assertFileExists(t, fs, filepath.Join(targetDir, "fileA2.txt"))
+		assertFileNotExists(t, fs, filepath.Join(targetDir, "fileB1.txt"))
+		assertFileNotExists(t, fs, filepath.Join(targetDir, "fileC1.txt"))
+	})
+	t.Run("copy with multiple technology filter", func(t *testing.T) {
+		t.Cleanup(func() {
+			_ = fs.RemoveAll(targetDir)
+			_ = fs.MkdirAll(targetDir, 0755)
+		})
+
+		technology = "java,python"
+		err := copyByTechnology(fs)
+		require.NoError(t, err)
+
+		assertFileExists(t, fs, filepath.Join(targetDir, "fileA1.txt"))
+		assertFileExists(t, fs, filepath.Join(targetDir, "fileA2.txt"))
+		assertFileExists(t, fs, filepath.Join(targetDir, "fileB1.txt"))
+		assertFileNotExists(t, fs, filepath.Join(targetDir, "fileC1.txt"))
+	})
+	t.Run("copy with invalid technology filter", func(t *testing.T) {
+		t.Cleanup(func() {
+			_ = fs.RemoveAll(targetDir)
+			_ = fs.MkdirAll(targetDir, 0755)
+		})
+
+		technology = "php"
+		err := copyByTechnology(fs)
+		require.NoError(t, err)
+
+		assertFileNotExists(t, fs, filepath.Join(targetDir, "fileA1.txt"))
+		assertFileNotExists(t, fs, filepath.Join(targetDir, "fileA2.txt"))
+		assertFileNotExists(t, fs, filepath.Join(targetDir, "fileB1.txt"))
+		assertFileNotExists(t, fs, filepath.Join(targetDir, "fileC1.txt"))
+	})
+}
+
+func TestFilterFilesByTechnology(t *testing.T) {
+	fs := afero.Afero{Fs: afero.NewMemMapFs()}
+
+	sourceDir := "/source"
+	_ = fs.MkdirAll(sourceDir, 0755)
+	manifestContent := `{
+        "version": "1.0",
+        "technologies": {
+            "java": {
+                "x86": [
+                    {"path": "fileA1.txt", "version": "1.0", "md5": "abc123"},
+                    {"path": "fileA2.txt", "version": "1.0", "md5": "def456"}
+                ]
+            },
+            "python": {
+                "arm": [
+                    {"path": "fileB1.txt", "version": "1.0", "md5": "ghi789"}
+                ]
+            }
+        }
+    }`
+	_ = afero.WriteFile(fs, filepath.Join(sourceDir, "manifest.json"), []byte(manifestContent), 0644)
+	_ = afero.WriteFile(fs, filepath.Join(sourceDir, "fileA1.txt"), []byte("a1 content"), 0644)
+	_ = afero.WriteFile(fs, filepath.Join(sourceDir, "fileA2.txt"), []byte("a2 content"), 0644)
+	_ = afero.WriteFile(fs, filepath.Join(sourceDir, "fileB1.txt"), []byte("b1 content"), 0644)
+
+	t.Run("filter single technology", func(t *testing.T) {
+		paths, err := filterFilesByTechnology(fs, sourceDir, []string{"java"})
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{
+			filepath.Join(sourceDir, "fileA1.txt"),
+			filepath.Join(sourceDir, "fileA2.txt"),
+		}, paths)
+	})
+	t.Run("filter multiple technologies", func(t *testing.T) {
+		paths, err := filterFilesByTechnology(fs, sourceDir, []string{"java", "python"})
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{
+			filepath.Join(sourceDir, "fileA1.txt"),
+			filepath.Join(sourceDir, "fileA2.txt"),
+			filepath.Join(sourceDir, "fileB1.txt"),
+		}, paths)
+	})
+	t.Run("not filter non-existing technology", func(t *testing.T) {
+		paths, err := filterFilesByTechnology(fs, sourceDir, []string{"php"})
+		require.NoError(t, err)
+		assert.Empty(t, paths)
+	})
+	t.Run("filter with missing manifest", func(t *testing.T) {
+		fs := afero.Afero{Fs: afero.NewMemMapFs()}
+		paths, err := filterFilesByTechnology(fs, sourceDir, []string{"java"})
+		require.Error(t, err)
+		assert.Nil(t, paths)
+	})
+}


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-bootstrapper/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

[Ticket](https://dt-rnd.atlassian.net/browse/DAQ-3996)

With this a new parameter is added: `technology`

It is a comma separated list of technologies. If it is provided in a valid way, only those files will be copied over that have this technology. Namely, if the `manifest.json` looks like this (**NOTE** I assumed that the file has this structure, if it should not look like this please let me know.):

```{
        "version": "1.0",
        "technologies": {
            "java": {
                "x86": [
                    {"path": "...", "version": "1.0", "md5": "..."}
                ]
            },
            "python": {
                "arm": [
                    {"path": "...", "version": "1.0", "md5": "..."}
                ]
            }
        }
    }
```

and you filter by only `python`, only the files that are stored under the key `python` will be copied over.


<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

## How can this be tested?

Unit tests are straight forward and test it properly IMO.

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->