### PR TITLE
Make `atomic` actually atomic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN --mount=type=cache,target="/root/.cache/go-build" \
     go build -tags -trimpath -ldflags="${GO_LINKER_ARGS}" \
     -o ./build/_output/bin/dynatrace-bootstrapper
 
-FROM public.ecr.aws/dynatrace/dynatrace-codemodules:1.299.73.20250109-153420 AS codemodules
+FROM --platform=$TARGETPLATFORM public.ecr.aws/dynatrace/dynatrace-codemodules:1.299.73.20250109-153420 AS codemodules
 
 # copy bootstrapper binary
 COPY --from=build /app/build/_output/bin /opt/dynatrace/oneagent/agent/lib64/
@@ -25,8 +25,8 @@ LABEL name="Dynatrace Bootstrapper" \
       vendor="Dynatrace LLC" \
       maintainer="Dynatrace LLC"
 
-      ENV USER_UID=1001 \
-          USER_NAME=dynatrace-bootstrapper
+ENV USER_UID=1001 \
+    USER_NAME=dynatrace-bootstrapper
 
 USER ${USER_UID}:${USER_UID}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# check=skip=RedundantTargetPlatform
 # setup build image
 FROM --platform=$BUILDPLATFORM golang:1.23.4@sha256:c25964d301e6c50174d29deadbbaa5ea6443e94b61087b6d89e8f41ef4ebca35 AS build
 
@@ -16,6 +17,7 @@ RUN --mount=type=cache,target="/root/.cache/go-build" \
     go build -tags -trimpath -ldflags="${GO_LINKER_ARGS}" \
     -o ./build/_output/bin/dynatrace-bootstrapper
 
+# platform is required, otherwise the copy command will copy the wrong architecture files, don't trust GitHub Actions linting warnings
 FROM --platform=$TARGETPLATFORM public.ecr.aws/dynatrace/dynatrace-codemodules:1.299.73.20250109-153420 AS codemodules
 
 # copy bootstrapper binary

--- a/pkg/move/atomic.go
+++ b/pkg/move/atomic.go
@@ -17,6 +17,10 @@ func atomic(copy copyFunc) copyFunc {
 
 			return err
 		}
+		defer func(){
+			// first remove is there for safety in case of unexpected error, this for the proper cleanup
+			_ = fs.RemoveAll(workFolder)
+		}()
 
 		err = fs.MkdirAll(workFolder, os.ModePerm)
 		if err != nil {

--- a/pkg/move/atomic.go
+++ b/pkg/move/atomic.go
@@ -25,7 +25,7 @@ func atomic(copy copyFunc) copyFunc {
 			return err
 		}
 
-		defer func(){
+		defer func() {
 			if err != nil {
 				if cleanupErr := fs.RemoveAll(workFolder); cleanupErr != nil {
 					logrus.Errorf("Failed cleanup of workdir after failure: %v", err)

--- a/pkg/move/atomic.go
+++ b/pkg/move/atomic.go
@@ -17,10 +17,6 @@ func atomic(copy copyFunc) copyFunc {
 
 			return err
 		}
-		defer func(){
-			// first remove is there for safety in case of unexpected error, this for the proper cleanup
-			_ = fs.RemoveAll(workFolder)
-		}()
 
 		err = fs.MkdirAll(workFolder, os.ModePerm)
 		if err != nil {
@@ -28,13 +24,6 @@ func atomic(copy copyFunc) copyFunc {
 
 			return err
 		}
-
-		defer func() {
-			err := fs.RemoveAll(workFolder)
-			if err != nil {
-				logrus.Errorf("Failed to do cleanup after run: %v", err)
-			}
-		}()
 
 		err = copy(fs, from, workFolder)
 		if err != nil {

--- a/pkg/move/atomic.go
+++ b/pkg/move/atomic.go
@@ -7,18 +7,18 @@ import (
 	"github.com/spf13/afero"
 )
 
-func atomic(copy copyFunc) copyFunc {
+func atomic(work string, copy copyFunc) copyFunc {
 	return func(fs afero.Afero, from, to string) (err error) {
 		logrus.Infof("Setting up atomic operation from %s to %s", from, to)
 
-		err = fs.RemoveAll(workFolder)
+		err = fs.RemoveAll(work)
 		if err != nil {
 			logrus.Errorf("Failed initial cleanup of workdir: %v", err)
 
 			return err
 		}
 
-		err = fs.MkdirAll(workFolder, os.ModePerm)
+		err = fs.MkdirAll(work, os.ModePerm)
 		if err != nil {
 			logrus.Errorf("Failed to create the base workdir: %v", err)
 
@@ -27,27 +27,27 @@ func atomic(copy copyFunc) copyFunc {
 
 		defer func() {
 			if err != nil {
-				if cleanupErr := fs.RemoveAll(workFolder); cleanupErr != nil {
+				if cleanupErr := fs.RemoveAll(work); cleanupErr != nil {
 					logrus.Errorf("Failed cleanup of workdir after failure: %v", err)
 				}
 			}
 		}()
 
-		err = copy(fs, from, workFolder)
+		err = copy(fs, from, work)
 		if err != nil {
 			logrus.Errorf("Error copying folder: %v", err)
 
 			return err
 		}
 
-		err = fs.Rename(workFolder, to)
+		err = fs.Rename(work, to)
 		if err != nil {
 			logrus.Errorf("Error moving folder: %v", err)
 
 			return err
 		}
 
-		logrus.Infof("Successfully finalized atomic operation from %s to %s", workFolder, to)
+		logrus.Infof("Successfully finalized atomic operation from %s to %s", work, to)
 
 		return nil
 	}

--- a/pkg/move/atomic_test.go
+++ b/pkg/move/atomic_test.go
@@ -11,7 +11,7 @@ import (
 const tmpWorkFolder = "/work/tmp"
 
 func mockCopyFunc(isSuccessful bool) copyFunc {
-	return func(fs afero.Afero) error {
+	return func(fs afero.Afero, _, _ string) error {
 		if isSuccessful {
 			_ = fs.MkdirAll(tmpWorkFolder, 0755)
 			return nil
@@ -32,7 +32,7 @@ func TestAtomic(t *testing.T) {
 
 		atomicCopy := atomic(mockCopyFunc(true))
 
-		err = atomicCopy(fs)
+		err = atomicCopy(fs, sourceFolder, targetFolder)
 		assert.NoError(t, err)
 
 		exists, err := fs.DirExists(workFolder)
@@ -47,7 +47,7 @@ func TestAtomic(t *testing.T) {
 
 		atomicCopy := atomic(mockCopyFunc(false))
 
-		err := atomicCopy(fs)
+		err := atomicCopy(fs, sourceFolder, targetFolder)
 		assert.Error(t, err)
 		assert.Equal(t, "some mock error", err.Error())
 

--- a/pkg/move/atomic_test.go
+++ b/pkg/move/atomic_test.go
@@ -14,12 +14,11 @@ func mockCopyFuncWithAtomicCheck(t *testing.T, isSuccessful bool) copyFunc {
 	t.Helper()
 
 	return func(fs afero.Afero, _, targetFolder string) error {
-
 		// according to the inner copyFunc, the targetFolder should be the workFolder
 		// the actual targetFolder will be created outside the copyFunc by the atomic wrapper using fs.Rename
 		require.Equal(t, workFolder, targetFolder)
 
-		// the atomicWrapper should already have created the base workFolder
+		// the atomic wrapper should already have created the base workFolder
 		exists, err := fs.DirExists(targetFolder)
 		require.NoError(t, err)
 		require.True(t, exists)
@@ -28,6 +27,7 @@ func mockCopyFuncWithAtomicCheck(t *testing.T, isSuccessful bool) copyFunc {
 			file, err := fs.Create(filepath.Join(targetFolder, "test.txt"))
 			require.NoError(t, err)
 			file.Close()
+
 			return nil
 		}
 

--- a/pkg/move/atomic_test.go
+++ b/pkg/move/atomic_test.go
@@ -2,16 +2,32 @@ package move
 
 import (
 	"errors"
+	"path/filepath"
 	"testing"
 
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func mockCopyFunc(isSuccessful bool) copyFunc {
+func mockCopyFuncWithAtomicCheck(t *testing.T, isSuccessful bool) copyFunc {
+	t.Helper()
+
 	return func(fs afero.Afero, _, targetFolder string) error {
+
+		// according to the inner copyFunc, the targetFolder should be the workFolder
+		// the actual targetFolder will be created outside the copyFunc by the atomic wrapper using fs.Rename
+		require.Equal(t, workFolder, targetFolder)
+
+		// the atomicWrapper should already have created the base workFolder
+		exists, err := fs.DirExists(targetFolder)
+		require.NoError(t, err)
+		require.True(t, exists)
+
 		if isSuccessful {
-			_ = fs.MkdirAll(targetFolder, 0755)
+			file, err := fs.Create(filepath.Join(targetFolder, "test.txt"))
+			require.NoError(t, err)
+			file.Close()
 			return nil
 		}
 
@@ -28,18 +44,22 @@ func TestAtomic(t *testing.T) {
 		err := fs.MkdirAll(sourceFolder, 0755)
 		assert.NoError(t, err)
 
-		atomicCopy := atomic(mockCopyFunc(true))
+		atomicCopy := atomic(mockCopyFuncWithAtomicCheck(t, true))
 
 		err = atomicCopy(fs, sourceFolder, targetFolder)
 		assert.NoError(t, err)
 
-		exists, err := fs.DirExists(workFolder)
+		isEmpty, err := fs.DirExists(workFolder)
 		assert.NoError(t, err)
-		assert.False(t, exists)
+		assert.False(t, isEmpty)
 
-		exists, err = fs.DirExists(targetFolder)
+		isEmpty, err = fs.DirExists(targetFolder)
 		assert.NoError(t, err)
-		assert.True(t, exists)
+		assert.True(t, isEmpty)
+
+		isEmpty, err = fs.IsEmpty(targetFolder)
+		assert.NoError(t, err)
+		assert.False(t, isEmpty)
 	})
 	t.Run("fail -> targetFolder is not present", func(t *testing.T) {
 		fs := afero.Afero{Fs: afero.NewMemMapFs()}
@@ -47,7 +67,7 @@ func TestAtomic(t *testing.T) {
 		targetFolder = "/target"
 		workFolder = "/work"
 
-		atomicCopy := atomic(mockCopyFunc(false))
+		atomicCopy := atomic(mockCopyFuncWithAtomicCheck(t, false))
 
 		err := atomicCopy(fs, sourceFolder, targetFolder)
 		assert.Error(t, err)

--- a/pkg/move/atomic_test.go
+++ b/pkg/move/atomic_test.go
@@ -8,12 +8,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const tmpWorkFolder = "/work/tmp"
-
 func mockCopyFunc(isSuccessful bool) copyFunc {
-	return func(fs afero.Afero, _, _ string) error {
+	return func(fs afero.Afero, _, targetFolder string) error {
 		if isSuccessful {
-			_ = fs.MkdirAll(tmpWorkFolder, 0755)
+			_ = fs.MkdirAll(targetFolder, 0755)
 			return nil
 		}
 
@@ -38,6 +36,10 @@ func TestAtomic(t *testing.T) {
 		exists, err := fs.DirExists(workFolder)
 		assert.NoError(t, err)
 		assert.False(t, exists)
+
+		exists, err = fs.DirExists(targetFolder)
+		assert.NoError(t, err)
+		assert.True(t, exists)
 	})
 	t.Run("fail -> targetFolder is not present", func(t *testing.T) {
 		fs := afero.Afero{Fs: afero.NewMemMapFs()}
@@ -52,6 +54,10 @@ func TestAtomic(t *testing.T) {
 		assert.Equal(t, "some mock error", err.Error())
 
 		exists, err := fs.DirExists(workFolder)
+		assert.NoError(t, err)
+		assert.False(t, exists)
+
+		exists, err = fs.DirExists(targetFolder)
 		assert.NoError(t, err)
 		assert.False(t, exists)
 	})

--- a/pkg/move/atomic_test.go
+++ b/pkg/move/atomic_test.go
@@ -37,6 +37,7 @@ func mockCopyFuncWithAtomicCheck(t *testing.T, isSuccessful bool) copyFunc {
 func TestAtomic(t *testing.T) {
 	source := "/source"
 	target := "/target"
+	work := "/work"
 
 	t.Run("success -> target is present", func(t *testing.T) {
 		fs := afero.Afero{Fs: afero.NewMemMapFs()}
@@ -45,7 +46,7 @@ func TestAtomic(t *testing.T) {
 		err := fs.MkdirAll(source, 0755)
 		assert.NoError(t, err)
 
-		atomicCopy := atomic(mockCopyFuncWithAtomicCheck(t, true))
+		atomicCopy := atomic(work, mockCopyFuncWithAtomicCheck(t, true))
 
 		err = atomicCopy(fs, source, target)
 		assert.NoError(t, err)
@@ -66,9 +67,8 @@ func TestAtomic(t *testing.T) {
 	})
 	t.Run("fail -> target is not present", func(t *testing.T) {
 		fs := afero.Afero{Fs: afero.NewMemMapFs()}
-		workFolder = "/work"
 
-		atomicCopy := atomic(mockCopyFuncWithAtomicCheck(t, false))
+		atomicCopy := atomic(work, mockCopyFuncWithAtomicCheck(t, false))
 
 		err := atomicCopy(fs, source, target)
 		assert.Error(t, err)

--- a/pkg/move/cmd.go
+++ b/pkg/move/cmd.go
@@ -45,5 +45,5 @@ func Execute(fs afero.Afero) error {
 		copy = atomic(copy)
 	}
 
-	return copy(fs)
+	return copy(fs, sourceFolder, targetFolder)
 }

--- a/pkg/move/cmd.go
+++ b/pkg/move/cmd.go
@@ -42,7 +42,7 @@ func Execute(fs afero.Afero) error {
 	}
 
 	if workFolder != "" {
-		copy = atomic(copy)
+		copy = atomic(workFolder, copy)
 	}
 
 	return copy(fs, sourceFolder, targetFolder)

--- a/pkg/move/copy.go
+++ b/pkg/move/copy.go
@@ -10,24 +10,26 @@ import (
 	"github.com/spf13/afero"
 )
 
-type copyFunc func(fs afero.Afero) error
+type copyFunc func(fs afero.Afero, from, to string) error
 
-func simpleCopy(fs afero.Afero) error {
-	logrus.Infof("Starting to copy (simple) from %s to %s", sourceFolder, targetFolder)
+var _ copyFunc = simpleCopy
 
-	err := copyFolder(fs, sourceFolder, targetFolder)
+func simpleCopy(fs afero.Afero, from, to string) error {
+	logrus.Infof("Starting to copy (simple) from %s to %s", from, to)
+
+	err := copyFolder(fs, from, to)
 	if err != nil {
 		logrus.Errorf("Error moving folder: %v", err)
 
 		return err
 	}
 
-	logrus.Infof("Successfully copied from %s to %s", sourceFolder, targetFolder)
+	logrus.Infof("Successfully copied from %s to %s", from, to)
 
 	return nil
 }
 
-func copyFolder(fs afero.Fs, from string, to string) error {
+func copyFolder(fs afero.Fs, from, to string) error {
 	fromInfo, err := fs.Stat(from)
 	if err != nil {
 		return errors.WithStack(err)
@@ -71,8 +73,8 @@ func copyFolder(fs afero.Fs, from string, to string) error {
 	return nil
 }
 
-func copyFile(fs afero.Fs, sourcePath string, destinationPath string) error {
-	sourceFile, err := fs.Open(sourcePath)
+func copyFile(fs afero.Fs, from string, to string) error {
+	sourceFile, err := fs.Open(from)
 	if err != nil {
 		return errors.WithStack(err)
 	}
@@ -83,7 +85,7 @@ func copyFile(fs afero.Fs, sourcePath string, destinationPath string) error {
 		return errors.WithStack(err)
 	}
 
-	destinationFile, err := fs.OpenFile(destinationPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, sourceInfo.Mode())
+	destinationFile, err := fs.OpenFile(to, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, sourceInfo.Mode())
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/pkg/move/technologies.go
+++ b/pkg/move/technologies.go
@@ -24,18 +24,20 @@ type FileEntry struct {
 	MD5     string `json:"md5"`
 }
 
-func copyByTechnology(fs afero.Afero) error {
-	logrus.Infof("Starting to copy (filtered) from %s to %s", sourceFolder, targetFolder)
+var _ copyFunc = copyByTechnology
 
-	filteredPaths, err := filterFilesByTechnology(fs, sourceFolder, strings.Split(technology, ","))
+func copyByTechnology(fs afero.Afero, from string, to string) error {
+	logrus.Infof("Starting to copy (filtered) from %s to %s", from, to)
+
+	filteredPaths, err := filterFilesByTechnology(fs, from, strings.Split(technology, ","))
 	if err != nil {
 		return err
 	}
 
 	for _, path := range filteredPaths {
-		targetFile := filepath.Join(targetFolder, strings.Split(path, sourceFolder)[1])
+		targetFile := filepath.Join(to, strings.Split(path, from)[1])
 
-		sourceStatMode, err := fs.Stat(sourceFolder)
+		sourceStatMode, err := fs.Stat(from)
 		if err != nil {
 			logrus.Errorf("Error checking stat mode from source folder: %v", err)
 

--- a/pkg/move/technologies_test.go
+++ b/pkg/move/technologies_test.go
@@ -15,9 +15,6 @@ func TestCopyFolderWithTechnologyFiltering(t *testing.T) {
 	sourceDir := "/source"
 	targetDir := "/target"
 
-	sourceFolder = sourceDir
-	targetFolder = targetDir
-
 	_ = fs.MkdirAll(sourceDir, 0755)
 	_ = fs.MkdirAll(targetDir, 0755)
 
@@ -51,7 +48,7 @@ func TestCopyFolderWithTechnologyFiltering(t *testing.T) {
 		})
 
 		technology = "java"
-		err := copyByTechnology(fs)
+		err := copyByTechnology(fs, sourceDir, targetDir)
 		require.NoError(t, err)
 
 		assertFileExists(t, fs, filepath.Join(targetDir, "fileA1.txt"))
@@ -66,7 +63,7 @@ func TestCopyFolderWithTechnologyFiltering(t *testing.T) {
 		})
 
 		technology = "java,python"
-		err := copyByTechnology(fs)
+		err := copyByTechnology(fs, sourceDir, targetDir)
 		require.NoError(t, err)
 
 		assertFileExists(t, fs, filepath.Join(targetDir, "fileA1.txt"))
@@ -81,7 +78,7 @@ func TestCopyFolderWithTechnologyFiltering(t *testing.T) {
 		})
 
 		technology = "php"
-		err := copyByTechnology(fs)
+		err := copyByTechnology(fs, sourceDir, targetDir)
 		require.NoError(t, err)
 
 		assertFileNotExists(t, fs, filepath.Join(targetDir, "fileA1.txt"))


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-bootstrapper/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

`atomic` was supposed to do a `fs.Rename` to make the actual copy between disc be atomic.

Also includes changes to move away from using the package level `vars` in functions outside of `AddFlags` and `Execute`:
- This improves unit testing, so you don't have to mess with the package level vars
- Is just clearer

In the future I would like it that these `vars` were only visible in `AddFlags` and `Execute` so they can't be used by accident in functions like `simpleCopy` and `atomic`. But right now I don't have a good idea how to achieve that.

## How can this be tested?
Use the sample, or a [related Operator change](https://github.com/Dynatrace/dynatrace-operator/pull/4419)