### PR TITLE
Add `--silent` arg to silence runtime errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,22 @@ The `dynatrace-bootstrapper` is a small CLI binary built into a [Dynatrace CodeM
 - This is an **optional** arg
 - The `--attribute-container` arg defines the passed in Container attributes that will be used to configure the metadata-enrichment and injected CodeModule. It is a JSON formatted string.
 
+#### `--silent`
+
+*Example*: `--silent=true`
+
+- This is an **optional** arg
+  - Defaults to `false`
+- The `--silent` arg will silence any errors, causing the executable to return with an exit code 0 even if an error occurred. Intended purpose is not to fail the whole Pod if used as init-container.
+
+#### `--debug`
+
+*Example*: `--debug=true`
+
+- This is an **optional** arg
+  - Defaults to `false`
+- The `--debug` arg will enabled the debug logs.
+
 ## Development
 
 - To run tests: `make test`

--- a/main.go
+++ b/main.go
@@ -80,6 +80,7 @@ func run(fs afero.Fs) func(cmd *cobra.Command, _ []string) error {
 		if err != nil {
 			if isSilent {
 				log.Error(err, "error during moving, silent fail is enabled")
+
 				return nil
 			}
 			return err
@@ -89,6 +90,7 @@ func run(fs afero.Fs) func(cmd *cobra.Command, _ []string) error {
 		if err != nil {
 			if isSilent {
 				log.Error(err, "error during configuration, silent fail is enabled")
+
 				return nil
 			}
 			return err

--- a/main_test.go
+++ b/main_test.go
@@ -23,4 +23,21 @@ func TestBootstrapper(t *testing.T) {
 
 		require.NoError(t, err)
 	})
+
+	t.Run("--silent=true -> no error", func(t *testing.T) {
+		cmd := bootstrapper(afero.NewMemMapFs())
+		cmd.SetArgs([]string{"--source", "\\\\", "--target", "\\\\"})
+
+		err := cmd.Execute()
+
+		require.Error(t, err)
+
+		cmd = bootstrapper(afero.NewMemMapFs())
+		// Note: we can't skip/mask the validation of the required flags
+		cmd.SetArgs([]string{"--source", "\\\\", "--target", "\\\\", "--silent", "true"})
+
+		err = cmd.Execute()
+
+		require.NoError(t, err)
+	})
 }


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-bootstrapper/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

New arg: `--silent=true` to make sure that the executable will return an exit code 0 even if there was an error in moving or configuring the codemodule

ℹ️ Note: we can't skip/mask the validation of the required flags (unless we want to implement our own inhouse solution for that, which I would like to avoid)

## How can this be tested?

The unittests are rather straightforward