### PR TITLE
Makes the source and target folder flags public

### DIFF
--- a/main.go
+++ b/main.go
@@ -15,8 +15,6 @@ import (
 )
 
 const (
-	SourceFolderFlag   = "source"
-	TargetFolderFlag   = "target"
 	DebugFlag          = "debug"
 	SuppressErrorsFlag = "suppress-error"
 )
@@ -25,9 +23,6 @@ var (
 	log                 logr.Logger
 	isDebug             bool
 	areErrorsSuppressed bool
-
-	sourceFolder string
-	targetFolder string
 )
 
 func main() {
@@ -55,12 +50,6 @@ func bootstrapper(fs afero.Fs) *cobra.Command {
 }
 
 func AddFlags(cmd *cobra.Command) {
-	cmd.PersistentFlags().StringVar(&sourceFolder, SourceFolderFlag, "", "Base path where to copy the codemodule FROM.")
-	_ = cmd.MarkPersistentFlagRequired(SourceFolderFlag)
-
-	cmd.PersistentFlags().StringVar(&targetFolder, TargetFolderFlag, "", "Base path where to copy the codemodule TO.")
-	_ = cmd.MarkPersistentFlagRequired(TargetFolderFlag)
-
 	cmd.PersistentFlags().BoolVar(&isDebug, DebugFlag, false, "(Optional) Enables debug logs.")
 	cmd.PersistentFlags().Lookup(DebugFlag).NoOptDefVal = "true"
 
@@ -81,7 +70,7 @@ func run(fs afero.Fs) func(cmd *cobra.Command, _ []string) error {
 			Fs: fs,
 		}
 
-		err := move.Execute(log, aferoFs, sourceFolder, targetFolder)
+		err := move.Execute(log, aferoFs, move.SourceFolder, move.TargetFolder)
 		if err != nil {
 			if areErrorsSuppressed {
 				log.Error(err, "error during moving, the error was suppressed")
@@ -91,7 +80,7 @@ func run(fs afero.Fs) func(cmd *cobra.Command, _ []string) error {
 			return err
 		}
 
-		err = configure.Execute(log, aferoFs, targetFolder)
+		err = configure.Execute(log, aferoFs, move.TargetFolder)
 		if err != nil {
 			if areErrorsSuppressed {
 				log.Error(err, "error during configuration, the error was suppressed")

--- a/pkg/move/cmd.go
+++ b/pkg/move/cmd.go
@@ -7,16 +7,30 @@ import (
 )
 
 const (
-	WorkFolderFlag = "work"
-	TechnologyFlag = "technology"
+	SourceFolderFlag = "source"
+	TargetFolderFlag = "target"
+	WorkFolderFlag   = "work"
+	TechnologyFlag   = "technology"
 )
 
 var (
 	workFolder string
 	technology string
+
+	// SourceFolder holds the value defined in the --source flag, only should be used if AddFlags was also used and part of a cobra.Command
+	SourceFolder string
+	// TargetFolder holds the value defined in the --target flag, only should be used if AddFlags was also used and part of a cobra.Command
+	TargetFolder string
 )
 
 func AddFlags(cmd *cobra.Command) {
+
+	cmd.PersistentFlags().StringVar(&SourceFolder, SourceFolderFlag, "", "Base path where to copy the codemodule FROM.")
+	_ = cmd.MarkPersistentFlagRequired(SourceFolderFlag)
+
+	cmd.PersistentFlags().StringVar(&TargetFolder, TargetFolderFlag, "", "Base path where to copy the codemodule TO.")
+	_ = cmd.MarkPersistentFlagRequired(TargetFolderFlag)
+
 	cmd.PersistentFlags().StringVar(&workFolder, WorkFolderFlag, "", "(Optional) Base path for a tmp folder, this is where the command will do its work, to make sure the operations are atomic. It must be on the same disk as the target folder.")
 
 	cmd.PersistentFlags().StringVar(&technology, TechnologyFlag, "", "(Optional) Comma-separated list of technologies to filter files.")


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-bootstrapper/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

Makes the `--source` and `--target` flags public, and moves it to the correct package (`move`)
- So we can use it in the operator repo, to reduce hard-coded values

A simple "hack" needed to be done, which is to make the `SourceFolder` and `TargetFolder` vars also public so they can be used in `main`.
- This is necessary because you can't import things FROM `main`

## How can this be tested?
(no change in actual behaviour)
Unittests are straight forward
or
`make deploy` -> things still get copied