### PR TITLE
Fix dev multiarch build by adding QEMU step

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -92,6 +92,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
       - name: Build target
         id: build-image
         uses: redhat-actions/buildah-build@7a95fa7ee0f02d552a32753e7414641a04307056 # v2.13

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM golang:1.24.1@sha256:c5adecdb7b3f8c5ca3c88648a861882849cc8b02fed68ece31e25de88ad13418 AS build
+# check=skip=RedundantTargetPlatform
+# setup build image
+FROM --platform=$BUILDPLATFORM golang:1.24.1@sha256:c5adecdb7b3f8c5ca3c88648a861882849cc8b02fed68ece31e25de88ad13418 AS build
 
 WORKDIR /app
 
@@ -6,15 +8,18 @@ COPY main.go go.mod go.sum ./
 RUN go mod download -x
 
 ARG GO_LINKER_ARGS
+ARG TARGETARCH
+ARG TARGETOS
 
 COPY pkg ./pkg
 COPY cmd ./cmd
 RUN --mount=type=cache,target="/root/.cache/go-build" \
-    CGO_ENABLED=0 \
+    CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH \
     go build -tags -trimpath -ldflags="${GO_LINKER_ARGS}" \
     -o ./build/_output/bin/dynatrace-bootstrapper
 
-FROM public.ecr.aws/dynatrace/dynatrace-codemodules:1.307.57.20250217-152612 AS codemodules
+# platform is required, otherwise the copy command will copy the wrong architecture files, don't trust GitHub Actions linting warnings
+FROM --platform=$TARGETPLATFORM public.ecr.aws/dynatrace/dynatrace-codemodules:1.307.57.20250217-152612 AS codemodules
 
 # copy bootstrapper binary
 COPY --from=build /app/build/_output/bin /opt/dynatrace/oneagent/agent/lib64/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
-# check=skip=RedundantTargetPlatform
-# setup build image
-FROM --platform=$BUILDPLATFORM golang:1.24.1@sha256:c5adecdb7b3f8c5ca3c88648a861882849cc8b02fed68ece31e25de88ad13418 AS build
+FROM golang:1.24.1@sha256:c5adecdb7b3f8c5ca3c88648a861882849cc8b02fed68ece31e25de88ad13418 AS build
 
 WORKDIR /app
 
@@ -8,18 +6,15 @@ COPY main.go go.mod go.sum ./
 RUN go mod download -x
 
 ARG GO_LINKER_ARGS
-ARG TARGETARCH
-ARG TARGETOS
 
 COPY pkg ./pkg
 COPY cmd ./cmd
 RUN --mount=type=cache,target="/root/.cache/go-build" \
-    CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH \
+    CGO_ENABLED=0 \
     go build -tags -trimpath -ldflags="${GO_LINKER_ARGS}" \
     -o ./build/_output/bin/dynatrace-bootstrapper
 
-# platform is required, otherwise the copy command will copy the wrong architecture files, don't trust GitHub Actions linting warnings
-FROM --platform=$TARGETPLATFORM public.ecr.aws/dynatrace/dynatrace-codemodules:1.307.57.20250217-152612 AS codemodules
+FROM public.ecr.aws/dynatrace/dynatrace-codemodules:1.307.57.20250217-152612 AS codemodules
 
 # copy bootstrapper binary
 COPY --from=build /app/build/_output/bin /opt/dynatrace/oneagent/agent/lib64/


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-bootstrapper/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

`buildah` says that it builds multiple archs, but only builds the `amd64` 4 times.

I missed that in the [official docs of the buildah step](https://github.com/marketplace/actions/buildah-build#emulating-run-instructions) it mentions that you have to have QEMU. (following the link in the docs, will lead you to the action I added)

## How can this be tested?

Test the image on an ARM env