### PR TITLE
Implement "current" symlink creation

### DIFF
--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -16,7 +16,10 @@ func TestBootstrapper(t *testing.T) {
 		require.Error(t, err)
 	})
 	t.Run("should validate required flags - present flags -> no error", func(t *testing.T) {
-		cmd := New(afero.NewMemMapFs())
+		fs := afero.NewMemMapFs()
+		_,_ = fs.Create("agent/bin/1.239.14.20220325-164521")
+
+		cmd := New(fs)
 		cmd.SetArgs([]string{"--source", "./", "--target", "./"})
 
 		err := cmd.Execute()
@@ -50,7 +53,10 @@ func TestBootstrapper(t *testing.T) {
 	})
 
 	t.Run("should allow unknown flags -> no error", func(t *testing.T) {
-		cmd := New(afero.NewMemMapFs())
+		fs := afero.NewMemMapFs()
+		_,_ = fs.Create("agent/bin/1.239.14.20220325-164521")
+
+		cmd := New(fs)
 		cmd.SetArgs([]string{"--source", "./", "--target", "./", "--unknown", "--flag", "value"})
 
 		err := cmd.Execute()

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -1,8 +1,10 @@
 package cmd
 
 import (
+	"path/filepath"
 	"testing"
 
+	"github.com/Dynatrace/dynatrace-bootstrapper/pkg/move"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/require"
 )
@@ -17,7 +19,7 @@ func TestBootstrapper(t *testing.T) {
 	})
 	t.Run("should validate required flags - present flags -> no error", func(t *testing.T) {
 		fs := afero.NewMemMapFs()
-		_,_ = fs.Create("agent/bin/1.239.14.20220325-164521")
+		_ = afero.WriteFile(fs, filepath.Join("./", move.InstallerVersionFilePath), []byte("123"), 0644)
 
 		cmd := New(fs)
 		cmd.SetArgs([]string{"--source", "./", "--target", "./"})
@@ -54,7 +56,7 @@ func TestBootstrapper(t *testing.T) {
 
 	t.Run("should allow unknown flags -> no error", func(t *testing.T) {
 		fs := afero.NewMemMapFs()
-		_,_ = fs.Create("agent/bin/1.239.14.20220325-164521")
+		_ = afero.WriteFile(fs, filepath.Join("./", move.InstallerVersionFilePath), []byte("123"), 0644)
 
 		cmd := New(fs)
 		cmd.SetArgs([]string{"--source", "./", "--target", "./", "--unknown", "--flag", "value"})

--- a/cmd/move/cmd.go
+++ b/cmd/move/cmd.go
@@ -37,5 +37,10 @@ func Execute(log logr.Logger, fs afero.Afero, from, to string) error {
 		copyFunc = impl.Atomic(workFolder, copyFunc)
 	}
 
-	return copyFunc(log, fs, from, to)
+	err := copyFunc(log, fs, from, to)
+	if err != nil {
+		return err
+	}
+
+	return impl.CreateCurrentSymlink(log, fs.Fs, to)
 }

--- a/cmd/move/cmd.go
+++ b/cmd/move/cmd.go
@@ -42,5 +42,5 @@ func Execute(log logr.Logger, fs afero.Afero, from, to string) error {
 		return err
 	}
 
-	return impl.CreateCurrentSymlink(log, fs.Fs, to)
+	return impl.CreateCurrentSymlink(log, fs, to)
 }

--- a/cmd/move/cmd_test.go
+++ b/cmd/move/cmd_test.go
@@ -16,7 +16,7 @@ func TestExecute(t *testing.T) {
 	sourceDir := "/source"
 	targetDir := "/target"
 
-	t.Run("package global vars are used", func(t *testing.T) {
+	t.Run("simple copy", func(t *testing.T) {
 		fs := afero.Afero{Fs: afero.NewMemMapFs()}
 
 		// Create source directory and files
@@ -24,6 +24,7 @@ func TestExecute(t *testing.T) {
 		_ = fs.MkdirAll(sourceDir, 0755)
 		_ = afero.WriteFile(fs, sourceDir+"/file1.txt", []byte("file1 content"), 0644)
 		_ = afero.WriteFile(fs, sourceDir+"/file2.txt", []byte("file2 content"), 0644)
+		_ = afero.WriteFile(fs, sourceDir+"/agent/bin/1.239.14.20220325-164521", []byte("file2 content"), 0644)
 
 		workFolder = workDir
 
@@ -65,7 +66,8 @@ func TestExecute(t *testing.T) {
 			"technologies": {
 				"java": {
 					"x86": [
-						{"path": "fileA1.txt", "version": "1.0", "md5": "abc123"}
+						{"path": "fileA1.txt", "version": "1.0", "md5": "abc123"},
+						{"path": "agent/bin/1.239.14.20220325-164521", "version": "1.0", "md5": "abc123"}
 					]
 				},
 				"python": {
@@ -81,6 +83,7 @@ func TestExecute(t *testing.T) {
 		_ = afero.WriteFile(fs, sourceDir+"/manifest.json", []byte(manifestContent), 0644)
 		_ = afero.WriteFile(fs, sourceDir+"/fileA1.txt", []byte("fileA1 content"), 0644)
 		_ = afero.WriteFile(fs, sourceDir+"/fileA2.txt", []byte("fileA2 content"), 0644)
+		_ = afero.WriteFile(fs, sourceDir+"/agent/bin/1.239.14.20220325-164521", []byte("file2 content"), 0644)
 
 		technology = technologyList
 

--- a/cmd/move/cmd_test.go
+++ b/cmd/move/cmd_test.go
@@ -1,8 +1,10 @@
 package move
 
 import (
+	"path/filepath"
 	"testing"
 
+	impl "github.com/Dynatrace/dynatrace-bootstrapper/pkg/move"
 	"github.com/go-logr/zapr"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
@@ -24,7 +26,7 @@ func TestExecute(t *testing.T) {
 		_ = fs.MkdirAll(sourceDir, 0755)
 		_ = afero.WriteFile(fs, sourceDir+"/file1.txt", []byte("file1 content"), 0644)
 		_ = afero.WriteFile(fs, sourceDir+"/file2.txt", []byte("file2 content"), 0644)
-		_,_ = fs.Create(sourceDir+"/agent/bin/1.239.14.20220325-164521")
+		_ = afero.WriteFile(fs, filepath.Join(sourceDir, impl.InstallerVersionFilePath), []byte("123"), 0644)
 
 		workFolder = workDir
 
@@ -67,7 +69,7 @@ func TestExecute(t *testing.T) {
 				"java": {
 					"x86": [
 						{"path": "fileA1.txt", "version": "1.0", "md5": "abc123"},
-						{"path": "agent/bin/1.239.14.20220325-164521", "version": "1.0", "md5": "abc123"}
+						{"path": "agent/installer.version", "version": "1.0", "md5": "abc123"}
 					]
 				},
 				"python": {
@@ -83,7 +85,7 @@ func TestExecute(t *testing.T) {
 		_ = afero.WriteFile(fs, sourceDir+"/manifest.json", []byte(manifestContent), 0644)
 		_ = afero.WriteFile(fs, sourceDir+"/fileA1.txt", []byte("fileA1 content"), 0644)
 		_ = afero.WriteFile(fs, sourceDir+"/fileA2.txt", []byte("fileA2 content"), 0644)
-		_,_ = fs.Create(sourceDir+"/agent/bin/1.239.14.20220325-164521")
+		_ = afero.WriteFile(fs, filepath.Join(sourceDir, impl.InstallerVersionFilePath), []byte("123"), 0644)
 
 		technology = technologyList
 

--- a/cmd/move/cmd_test.go
+++ b/cmd/move/cmd_test.go
@@ -24,7 +24,7 @@ func TestExecute(t *testing.T) {
 		_ = fs.MkdirAll(sourceDir, 0755)
 		_ = afero.WriteFile(fs, sourceDir+"/file1.txt", []byte("file1 content"), 0644)
 		_ = afero.WriteFile(fs, sourceDir+"/file2.txt", []byte("file2 content"), 0644)
-		_ = afero.WriteFile(fs, sourceDir+"/agent/bin/1.239.14.20220325-164521", []byte("file2 content"), 0644)
+		_,_ = fs.Create(sourceDir+"/agent/bin/1.239.14.20220325-164521")
 
 		workFolder = workDir
 
@@ -83,7 +83,7 @@ func TestExecute(t *testing.T) {
 		_ = afero.WriteFile(fs, sourceDir+"/manifest.json", []byte(manifestContent), 0644)
 		_ = afero.WriteFile(fs, sourceDir+"/fileA1.txt", []byte("fileA1 content"), 0644)
 		_ = afero.WriteFile(fs, sourceDir+"/fileA2.txt", []byte("fileA2 content"), 0644)
-		_ = afero.WriteFile(fs, sourceDir+"/agent/bin/1.239.14.20220325-164521", []byte("file2 content"), 0644)
+		_,_ = fs.Create(sourceDir+"/agent/bin/1.239.14.20220325-164521")
 
 		technology = technologyList
 

--- a/pkg/move/current.go
+++ b/pkg/move/current.go
@@ -1,72 +1,31 @@
 package move
 
 import (
-	iofs "io/fs"
 	"path/filepath"
-	"regexp"
 
 	"github.com/Dynatrace/dynatrace-bootstrapper/pkg/utils/fs/symlink"
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
 	"github.com/spf13/afero"
 )
 
 const (
-	// example match: 1.239.14.20220325-164521
-	versionRegexp = `^(\d+)\.(\d+)\.(\d+)\.(\d+)-(\d+)$`
-	binDir        = "/agent/bin"
-	currentDir    = "current"
+	InstallerVersionFilePath = "agent/installer.version"
+	currentDir               = "agent/bin/current"
 )
 
 // CreateCurrentSymlink finds a the version of the CodeModule in the `targetDir` and creates a "current" symlink next to it.
 // this is needed for the nginx use-case.
-func CreateCurrentSymlink(log logr.Logger, fs afero.Fs, targetDir string) error {
-	targetBinDir := filepath.Join(targetDir, binDir)
+func CreateCurrentSymlink(log logr.Logger, fs afero.Afero, targetDir string) error {
+	versionFilePath := filepath.Join(targetDir, InstallerVersionFilePath)
+	version, err := fs.ReadFile(versionFilePath)
 
-	relativeSymlinkPath, err := findVersionFromFS(log, fs, targetBinDir)
 	if err != nil {
-		log.Info("failed to get the version from the filesystem", "targetDir", targetDir)
+		log.Info("failed to get the version from the filesystem", "version-file", versionFilePath)
 
 		return err
 	}
 
-	return symlink.Create(log, fs, relativeSymlinkPath, filepath.Join(targetBinDir, currentDir))
-}
+	targetBinDir := filepath.Join(targetDir, currentDir)
 
-func findVersionFromFS(log logr.Logger, fs afero.Fs, targetBinDir string) (string, error) {
-	var version string
-
-	aferoFs := afero.Afero{
-		Fs: fs,
-	}
-	walkFiles := func(path string, info iofs.FileInfo, err error) error {
-		if info == nil {
-			log.Info(
-				"version sub-dir does not exist in dir",
-				"dir", targetBinDir)
-
-			return iofs.ErrNotExist
-		}
-
-		if !info.IsDir() {
-			return nil
-		}
-
-		folderName := filepath.Base(path)
-		if regexp.MustCompile(versionRegexp).Match([]byte(folderName)) {
-			log.Info("found version", "version", folderName)
-			version = folderName
-
-			return iofs.ErrExist
-		}
-
-		return nil
-	}
-
-	err := aferoFs.Walk(targetBinDir, walkFiles)
-	if errors.Is(err, iofs.ErrNotExist) {
-		return "", errors.WithStack(err)
-	}
-
-	return version, nil
+	return symlink.Create(log, fs.Fs, string(version), targetBinDir)
 }

--- a/pkg/move/current.go
+++ b/pkg/move/current.go
@@ -13,7 +13,7 @@ const (
 	currentDir               = "agent/bin/current"
 )
 
-// CreateCurrentSymlink finds the version of the CodeModule in the `targetDir` (in the installer.version file) and creates a "current" symlink next to it.
+// CreateCurrentSymlink finds the version of the CodeModule in the `targetDir` (in the installer.version file) and creates a "current" symlink in the agent/bin folder that points to the agent/bin/<version> subfolder.
 // this is needed for the nginx use-case.
 func CreateCurrentSymlink(log logr.Logger, fs afero.Afero, targetDir string) error {
 	targetCurrentDir := filepath.Join(targetDir, currentDir)

--- a/pkg/move/current.go
+++ b/pkg/move/current.go
@@ -1,0 +1,81 @@
+package move
+
+import (
+	iofs "io/fs"
+	"path/filepath"
+	"regexp"
+
+	"github.com/Dynatrace/dynatrace-bootstrapper/pkg/utils/fs/symlink"
+	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
+	"github.com/spf13/afero"
+)
+
+const (
+	// example match: 1.239.14.20220325-164521
+	versionRegexp = `^(\d+)\.(\d+)\.(\d+)\.(\d+)-(\d+)$`
+	binDir        = "/agent/bin"
+	currentDir    = "current"
+)
+
+// CreateCurrentSymlink finds a the version of the CodeModule in the `targetDir` and creates a "current" symlink next to it.
+// this is needed for the nginx use-case.
+func CreateCurrentSymlink(log logr.Logger, fs afero.Fs, targetDir string) error {
+	var err error
+
+	_, ok := fs.(afero.Linker)
+	if !ok {
+		log.Info("symlinking not possible", "targetDir", targetDir, "fs", fs)
+
+		return nil
+	}
+
+	targetBinDir := filepath.Join(targetDir, binDir)
+
+	relativeSymlinkPath, err := findVersionFromFS(log, fs, targetBinDir)
+	if err != nil {
+		log.Info("failed to get the version from the filesystem", "targetDir", targetDir)
+
+		return err
+	}
+
+	return symlink.Create(log, fs, relativeSymlinkPath, filepath.Join(targetBinDir, currentDir))
+}
+
+func findVersionFromFS(log logr.Logger, fs afero.Fs, targetDir string) (string, error) {
+	var version string
+
+	aferoFs := afero.Afero{
+		Fs: fs,
+	}
+	walkFiles := func(path string, info iofs.FileInfo, err error) error {
+		if info == nil {
+			log.Info(
+				"file does not exist, are you using a correct codeModules image?",
+				"path", path)
+
+			return iofs.ErrNotExist
+		}
+
+		if !info.IsDir() {
+			return nil
+		}
+
+		folderName := filepath.Base(path)
+		if regexp.MustCompile(versionRegexp).Match([]byte(folderName)) {
+			log.Info("found version", "version", folderName)
+			version = folderName
+
+			return iofs.ErrExist
+		}
+
+		return nil
+	}
+
+	err := aferoFs.Walk(targetDir, walkFiles)
+	if errors.Is(err, iofs.ErrNotExist) {
+		return "", errors.WithStack(err)
+	}
+
+	return version, nil
+}

--- a/pkg/move/current_test.go
+++ b/pkg/move/current_test.go
@@ -19,6 +19,15 @@ func TestCreateCurrentSymlink(t *testing.T) {
 		err := CreateCurrentSymlink(testLog, fs, testPath)
 		require.NoError(t, err)
 	})
+
+	t.Run("no fail if current dir already exists", func(t *testing.T) {
+		fs := afero.Afero{Fs: afero.NewMemMapFs()}
+		_ = fs.Fs.Mkdir(filepath.Join(testPath, currentDir), 0644)
+
+		err := CreateCurrentSymlink(testLog, fs, testPath)
+		require.NoError(t, err)
+	})
+
 	t.Run("fail if version file is missing", func(t *testing.T) {
 		fs := afero.Afero{Fs: afero.NewMemMapFs()}
 

--- a/pkg/move/current_test.go
+++ b/pkg/move/current_test.go
@@ -11,22 +11,22 @@ import (
 
 func TestFindVersionFromFileSystem(t *testing.T) {
 	testPath := "/test"
-	testVersion := "1.239.14.20220325-164521"
+	expectedVersion := "1.239.14.20220325-164521"
 
 	t.Run("get version from directory in file system", func(t *testing.T) {
 		fs := afero.NewMemMapFs()
-		err := fs.MkdirAll(filepath.Join(testPath, testVersion), 0755)
+		err := fs.MkdirAll(filepath.Join(testPath, expectedVersion), 0755)
 		require.NoError(t, err)
 
 		version, err := findVersionFromFS(testLog, fs, testPath)
 		require.NoError(t, err)
-		assert.Equal(t, testVersion, version)
+		assert.Equal(t, expectedVersion, version)
 	})
 	t.Run("get nothing from file", func(t *testing.T) {
 		fs := afero.NewMemMapFs()
 		err := fs.MkdirAll(testPath, 0755)
 		require.NoError(t, err)
-		_, err = fs.Create(filepath.Join(testPath, testVersion))
+		_, err = fs.Create(filepath.Join(testPath, expectedVersion))
 		require.NoError(t, err)
 
 		version, err := findVersionFromFS(testLog, fs, testPath)

--- a/pkg/move/current_test.go
+++ b/pkg/move/current_test.go
@@ -1,0 +1,36 @@
+package move
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFindVersionFromFileSystem(t *testing.T) {
+	testPath := "/test"
+	testVersion := "1.239.14.20220325-164521"
+
+	t.Run("get version from directory in file system", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+		err := fs.MkdirAll(filepath.Join(testPath, testVersion), 0755)
+		require.NoError(t, err)
+
+		version, err := findVersionFromFS(testLog, fs, testPath)
+		require.NoError(t, err)
+		assert.Equal(t, testVersion, version)
+	})
+	t.Run("get nothing from file", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+		err := fs.MkdirAll(testPath, 0755)
+		require.NoError(t, err)
+		_, err = fs.Create(filepath.Join(testPath, testVersion))
+		require.NoError(t, err)
+
+		version, err := findVersionFromFS(testLog, fs, testPath)
+		require.NoError(t, err)
+		assert.Empty(t, version)
+	})
+}

--- a/pkg/move/current_test.go
+++ b/pkg/move/current_test.go
@@ -22,7 +22,7 @@ func TestCreateCurrentSymlink(t *testing.T) {
 
 	t.Run("no fail if current dir already exists", func(t *testing.T) {
 		fs := afero.Afero{Fs: afero.NewMemMapFs()}
-		_ = fs.Fs.Mkdir(filepath.Join(testPath, currentDir), 0644)
+		_ = fs.Mkdir(filepath.Join(testPath, currentDir), 0644)
 
 		err := CreateCurrentSymlink(testLog, fs, testPath)
 		require.NoError(t, err)

--- a/pkg/utils/fs/symlink/symlink.go
+++ b/pkg/utils/fs/symlink/symlink.go
@@ -1,0 +1,34 @@
+package symlink
+
+import (
+	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
+	"github.com/spf13/afero"
+)
+
+func Create(log logr.Logger, fs afero.Fs, targetDir, symlinkDir string) error {
+	// MemMapFs (used for testing) doesn't comply with the Linker interface
+	linker, ok := fs.(afero.Linker)
+	if !ok {
+		log.Info("symlinking not possible", "targetDir", targetDir, "fs", fs)
+
+		return nil
+	}
+
+	// Check if the symlink already exists
+	if fileInfo, _ := fs.Stat(symlinkDir); fileInfo != nil {
+		log.Info("symlink already exists", "location", symlinkDir)
+
+		return nil
+	}
+
+	log.Info("creating symlink", "points-to(relative)", targetDir, "location", symlinkDir)
+
+	if err := linker.SymlinkIfPossible(targetDir, symlinkDir); err != nil {
+		log.Info("symlinking failed", "source", targetDir)
+
+		return errors.WithStack(err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-bootstrapper/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description
[DAQ-7462](https://dt-rnd.atlassian.net/browse/DAQ-7462)

As the last step of the move/copy, it will create a relative-symlink called `current` in the bin directory pointing  to the version sub-directory.

## How can this be tested?

When using `make deploy`, and shelling into the sample pod, you should see:
```bash
> ls -la /opt/dynatrace/oneagent/agent/bin/
total 28
drwxr-sr-x 7 root 2000 4096 Apr 17 06:59 .
drwxr-sr-x 8 root 2000 4096 Apr 17 06:59 ..
drwxr-sr-x 6 root 2000 4096 Apr 17 06:59 1.307.57.20250217-152612
drwxr-sr-x 2 root 2000 4096 Apr 17 06:59 any
lrwxrwxrwx 1 root 2000   24 Apr 17 06:59 current -> 1.307.57.20250217-152612
drwxr-sr-x 2 root 2000 4096 Apr 17 06:59 linux-musl-x86-64
drwxr-sr-x 2 root 2000 4096 Apr 17 06:59 linux-x86-32
drwxr-sr-x 2 root 2000 4096 Apr 17 06:59 linux-x86-64
```

[DAQ-7462]: https://dt-rnd.atlassian.net/browse/DAQ-7462?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ