### PR TITLE
Make function for reading certs on the filesystem public

### DIFF
--- a/pkg/configure/oneagent/ca/ca.go
+++ b/pkg/configure/oneagent/ca/ca.go
@@ -19,12 +19,12 @@ const (
 )
 
 func Configure(log logr.Logger, fs afero.Afero, inputDir, configDir string) error {
-	trustedCerts, err := getFromFs(fs, inputDir, TrustedCertsInputFile)
+	trustedCerts, err := GetFromFs(fs, inputDir, TrustedCertsInputFile)
 	if err != nil && !os.IsNotExist(err) {
 		return err
 	}
 
-	agCerts, err := getFromFs(fs, inputDir, AgCertsInputFile)
+	agCerts, err := GetFromFs(fs, inputDir, AgCertsInputFile)
 	if err != nil && !os.IsNotExist(err) {
 		return err
 	}
@@ -54,7 +54,7 @@ func Configure(log logr.Logger, fs afero.Afero, inputDir, configDir string) erro
 	return nil
 }
 
-func getFromFs(fs afero.Afero, inputDir, certFileName string) (string, error) {
+func GetFromFs(fs afero.Afero, inputDir, certFileName string) (string, error) {
 	inputFile := filepath.Join(inputDir, certFileName)
 
 	content, err := fs.ReadFile(inputFile)


### PR DESCRIPTION

<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-bootstrapper/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description
This should allows to use said function from the Dynatrace Operator.

Addresses [DAQ-7402](https://dt-rnd.atlassian.net/browse/DAQ-7402)

## How can this be tested?
```bash
make test
```

[DAQ-7402]: https://dt-rnd.atlassian.net/browse/DAQ-7402?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ