### PR TITLE
Fix the version printing

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,6 +1,8 @@
 package version
 
 import (
+	"runtime/debug"
+
 	"github.com/go-logr/logr"
 )
 
@@ -10,7 +12,7 @@ var (
 	AppName = "dynatrace-bootsrapper"
 
 	// Version contains the version of the Bootstrapper. Assigned externally.
-	Version = "snapshot"
+	Version = ""
 
 	// Commit indicates the Git commit hash the binary was build from. Assigned externally.
 	Commit = ""
@@ -20,5 +22,31 @@ var (
 )
 
 func Print(log logr.Logger) {
-	log.Info("version info", "name", AppName, "version", Version, "commit", Commit, "build_date", BuildDate)
+	keyValues := []any{"name", AppName,}
+
+	i, ok := debug.ReadBuildInfo()
+	if !ok {
+		return
+	}
+
+	if Version == "" {
+		Version = i.Main.Version
+	}
+
+	keyValues = append(keyValues, "version", Version)
+
+	if i.Main.Sum != "" {
+		keyValues = append(keyValues, "module-sum", i.Main.Sum)
+	}
+
+	if Commit != "" {
+		keyValues = append(keyValues, "commit", Commit)
+	}
+
+	if BuildDate != "" {
+		keyValues = append(keyValues, "build_date", BuildDate)
+	}
+
+
+	log.Info("version info", keyValues...)
 }


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-bootstrapper/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

Make the `version.Print` "smarter" by it reading the buildInfo to get the version, and only print things that are known.

based on how others do it:
- [crane](https://github.com/google/go-containerregistry/blob/c4dd792fa06c1f8b780ad90c8ab4f38b4eac05bd/cmd/crane/cmd/version.go#L29-L35)
- [cyclonedx](https://github.com/CycloneDX/cyclonedx-gomod/blob/7a093d9cd89f8fdc93f5b7c57a52566f417a2f11/internal/version/version.go#L43-L66)

## How can this be tested?

-