### PR TITLE
Add `--fullstack` and `--tenant="..."` flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,15 @@ The `dynatrace-bootstrapper` is a small CLI binary built into a [Dynatrace CodeM
 - The `--install-path` arg defines the base path where the agent binary will be put. This is only necessary to properly configure the `ld.so.preload` file.
   - The `ld.so.preload` is put under `<config-directory>/oneagent/ld.so.preload`
 
+#### `--fullstack`
+
+*Example*: `--fullstack`
+
+- This is an **optional** arg
+  - Defaults to `false`
+- The `--fullstack` arg will make sure that the CodeModule is configured to be in fullstack mode.
+  - Adds additional values to the `<config-directory>/<container-name>/oneagent/agent/config/container.conf`.
+
 #### `--attribute`
 
 *Example*: `--attribute="k8s.pod.name=test"`

--- a/README.md
+++ b/README.md
@@ -92,6 +92,13 @@ The `dynatrace-bootstrapper` is a small CLI binary built into a [Dynatrace CodeM
 - The `--fullstack` arg will make sure that the CodeModule is configured to be in fullstack mode.
   - Adds additional values to the `<config-directory>/<container-name>/oneagent/agent/config/container.conf`.
 
+#### `--tenant`
+
+*Example*: `--tenant="my-tenant"`
+
+- This is an **optional** arg, but mandatory incase of `--fullstack`.
+- Only used incase of `--fullstack`, provides additional info needed to properly configure `<config-directory>/<container-name>/oneagent/agent/config/container.conf`.
+
 #### `--attribute`
 
 *Example*: `--attribute="k8s.pod.name=test"`

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -89,15 +89,28 @@ func run(fs afero.Fs) func(cmd *cobra.Command, _ []string) error {
 			return err
 		}
 
-		err = configure.Execute(log, aferoFs, targetFolder)
+		err = configure.SetupOneAgent(log, aferoFs, targetFolder)
 		if err != nil {
 			if areErrorsSuppressed {
-				log.Error(err, "error during configuration, the error was suppressed")
+				log.Error(err, "error during oneagent setup, the error was suppressed")
 
 				return nil
 			}
 
 			log.Error(err, "error during configuration")
+
+			return err
+		}
+
+		err = configure.EnrichWithMetadata(log, aferoFs)
+		if err != nil {
+			if areErrorsSuppressed {
+				log.Error(err, "error during enrichment, the error was suppressed")
+
+				return nil
+			}
+
+			log.Error(err, "error during enrichment")
 
 			return err
 		}

--- a/cmd/configure/attributes/container/container.go
+++ b/cmd/configure/attributes/container/container.go
@@ -14,7 +14,7 @@ const (
 
 type Attributes struct {
 	ImageInfo     `json:",inline"`
-	ContainerName string `json:"k8s.container.name"`
+	ContainerName string `json:"k8s.container.name,omitempty"`
 }
 
 func (attr Attributes) ToMap() (map[string]string, error) {

--- a/cmd/configure/attributes/container/image.go
+++ b/cmd/configure/attributes/container/image.go
@@ -1,10 +1,10 @@
 package container
 
 type ImageInfo struct {
-	Registry    string `json:"container_image.registry"`
-	Repository  string `json:"container_image.repository"`
-	Tag         string `json:"container_image.tags"`
-	ImageDigest string `json:"container_image.digest"`
+	Registry    string `json:"container_image.registry,omitempty"`
+	Repository  string `json:"container_image.repository,omitempty"`
+	Tag         string `json:"container_image.tags,omitempty"`
+	ImageDigest string `json:"container_image.digest,omitempty"`
 }
 
 func (img ImageInfo) ToURI() string {

--- a/cmd/configure/attributes/pod/pod.go
+++ b/cmd/configure/attributes/pod/pod.go
@@ -39,7 +39,7 @@ type ClusterInfo struct {
 	ClusterUID      string `json:"k8s.cluster.uid"`
 	ClusterName     string `json:"k8s.cluster.name"`
 	DTClusterEntity string `json:"dt.entity.kubernetes_cluster"`
-	DTTenantUID     string `json:"dt.tenant"`
+	DTTenantUID     string `json:"dt.tenant,omitempty"`
 }
 
 func ParseAttributes(rawAttributes []string) (Attributes, error) {

--- a/cmd/configure/attributes/pod/pod.go
+++ b/cmd/configure/attributes/pod/pod.go
@@ -24,21 +24,21 @@ func (attr Attributes) ToMap() (map[string]string, error) {
 }
 
 type PodInfo struct {
-	PodName       string `json:"k8s.pod.name"`
-	PodUID        string `json:"k8s.pod.uid"`
-	NodeName      string `json:"k8s.node.name"`
-	NamespaceName string `json:"k8s.namespace.name"`
+	PodName       string `json:"k8s.pod.name,omitempty"`
+	PodUID        string `json:"k8s.pod.uid,omitempty"`
+	NodeName      string `json:"k8s.node.name,omitempty"`
+	NamespaceName string `json:"k8s.namespace.name,omitempty"`
 }
 
 type WorkloadInfo struct {
-	WorkloadKind string `json:"k8s.workload.kind"`
-	WorkloadName string `json:"k8s.workload.name"`
+	WorkloadKind string `json:"k8s.workload.kind,omitempty"`
+	WorkloadName string `json:"k8s.workload.name,omitempty"`
 }
 
 type ClusterInfo struct {
-	ClusterUID      string `json:"k8s.cluster.uid"`
-	ClusterName     string `json:"k8s.cluster.name"`
-	DTClusterEntity string `json:"dt.entity.kubernetes_cluster"`
+	ClusterUID      string `json:"k8s.cluster.uid,omitempty"`
+	ClusterName     string `json:"k8s.cluster.name,omitempty"`
+	DTClusterEntity string `json:"dt.entity.kubernetes_cluster,omitempty"`
 }
 
 func ParseAttributes(rawAttributes []string) (Attributes, error) {

--- a/cmd/configure/attributes/pod/pod.go
+++ b/cmd/configure/attributes/pod/pod.go
@@ -39,7 +39,6 @@ type ClusterInfo struct {
 	ClusterUID      string `json:"k8s.cluster.uid"`
 	ClusterName     string `json:"k8s.cluster.name"`
 	DTClusterEntity string `json:"dt.entity.kubernetes_cluster"`
-	DTTenantUID     string `json:"dt.tenant,omitempty"`
 }
 
 func ParseAttributes(rawAttributes []string) (Attributes, error) {

--- a/cmd/configure/attributes/pod/pod.go
+++ b/cmd/configure/attributes/pod/pod.go
@@ -39,6 +39,7 @@ type ClusterInfo struct {
 	ClusterUID      string `json:"k8s.cluster.uid"`
 	ClusterName     string `json:"k8s.cluster.name"`
 	DTClusterEntity string `json:"dt.entity.kubernetes_cluster"`
+	DTTenantUID     string `json:"dt.tenant"`
 }
 
 func ParseAttributes(rawAttributes []string) (Attributes, error) {

--- a/cmd/configure/cmd.go
+++ b/cmd/configure/cmd.go
@@ -49,7 +49,7 @@ func AddFlags(cmd *cobra.Command) {
 
 	cmd.PersistentFlags().BoolVar(&isFullstack, IsFullstackFlag, false, "(Optional) Configure the CodeModule to be fullstack.")
 
-	cmd.PersistentFlags().Lookup(IsFullstackFlag).NoOptDefVal = "false"
+	cmd.PersistentFlags().Lookup(IsFullstackFlag).NoOptDefVal = "true"
 
 	cmd.PersistentFlags().StringVar(&tenant, TenantFlag, "", "The name of the tenant that the CodeModule will communicate with. Mandatory in case of --fullstack.")
 }

--- a/cmd/configure/cmd.go
+++ b/cmd/configure/cmd.go
@@ -61,10 +61,6 @@ func Execute(log logr.Logger, fs afero.Afero, targetDir string) error {
 
 	log.Info("starting configuration", "config-directory", configFolder, "input-directory", inputFolder)
 
-	if isFullstack {
-		log.Info("fullstack flag detected, configuring accordingly", "tenant", tenant)
-	}
-
 	err := preload.Configure(log, fs, configFolder, installPath)
 	if err != nil {
 		log.Info("failed to configure the ld.so.preload", "config-directory", configFolder)

--- a/cmd/configure/cmd.go
+++ b/cmd/configure/cmd.go
@@ -61,6 +61,10 @@ func Execute(log logr.Logger, fs afero.Afero, targetDir string) error {
 
 	log.Info("starting configuration", "config-directory", configFolder, "input-directory", inputFolder)
 
+	if isFullstack {
+		log.Info("fullstack flag detected, configuring accordingly", "tenant", tenant)
+	}
+
 	err := preload.Configure(log, fs, configFolder, installPath)
 	if err != nil {
 		log.Info("failed to configure the ld.so.preload", "config-directory", configFolder)

--- a/cmd/configure/cmd.go
+++ b/cmd/configure/cmd.go
@@ -22,6 +22,7 @@ const (
 	ConfigFolderFlag = "config-directory"
 	InstallPathFlag  = "install-path"
 	IsFullstackFlag  = "fullstack"
+	TenantFlag       = "tenant"
 )
 
 var (
@@ -29,6 +30,7 @@ var (
 	configFolder string
 	installPath  = "/opt/dynatrace/oneagent"
 	isFullstack  bool
+	tenant       string
 
 	podAttributes       []string
 	containerAttributes []string
@@ -48,6 +50,8 @@ func AddFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().BoolVar(&isFullstack, IsFullstackFlag, false, "(Optional) Configure the CodeModule to be fullstack.")
 
 	cmd.PersistentFlags().Lookup(IsFullstackFlag).NoOptDefVal = "false"
+
+	cmd.PersistentFlags().StringVar(&tenant, TenantFlag, "", "The name of the tenant that the CodeModule will communicate with. Mandatory in case of --fullstack.")
 }
 
 func Execute(log logr.Logger, fs afero.Afero, targetDir string) error {
@@ -98,7 +102,7 @@ func Execute(log logr.Logger, fs afero.Afero, targetDir string) error {
 			return err
 		}
 
-		err = conf.Configure(log, fs, containerConfigDir, containerAttr, podAttr, isFullstack)
+		err = conf.Configure(log, fs, containerConfigDir, containerAttr, podAttr, tenant, isFullstack)
 		if err != nil {
 			log.Info("failed to configure the container-conf files", "config-directory", containerConfigDir)
 

--- a/cmd/configure/cmd.go
+++ b/cmd/configure/cmd.go
@@ -21,12 +21,14 @@ const (
 	InputFolderFlag  = "input-directory"
 	ConfigFolderFlag = "config-directory"
 	InstallPathFlag  = "install-path"
+	FullstackFlag    = "fullstack"
 )
 
 var (
 	inputFolder  string
 	configFolder string
 	installPath  = "/opt/dynatrace/oneagent"
+	isFullstack  bool
 
 	podAttributes       []string
 	containerAttributes []string
@@ -42,6 +44,8 @@ func AddFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringArrayVar(&containerAttributes, container.Flag, []string{}, "(Optional) Container-specific attributes in JSON format.")
 
 	cmd.PersistentFlags().StringArrayVar(&podAttributes, pod.Flag, []string{}, "(Optional) Pod-specific attributes in key=value format.")
+
+	cmd.PersistentFlags().BoolVar(&isFullstack, FullstackFlag, false, "(Optional) Configure the CodeModule to be fullstack.")
 }
 
 func Execute(log logr.Logger, fs afero.Afero, targetDir string) error {
@@ -92,7 +96,7 @@ func Execute(log logr.Logger, fs afero.Afero, targetDir string) error {
 			return err
 		}
 
-		err = conf.Configure(log, fs, containerConfigDir, containerAttr, podAttr)
+		err = conf.Configure(log, fs, containerConfigDir, containerAttr, podAttr, isFullstack)
 		if err != nil {
 			log.Info("failed to configure the container-conf files", "config-directory", containerConfigDir)
 

--- a/cmd/configure/cmd.go
+++ b/cmd/configure/cmd.go
@@ -21,7 +21,7 @@ const (
 	InputFolderFlag  = "input-directory"
 	ConfigFolderFlag = "config-directory"
 	InstallPathFlag  = "install-path"
-	FullstackFlag    = "fullstack"
+	IsFullstackFlag  = "fullstack"
 )
 
 var (
@@ -45,9 +45,9 @@ func AddFlags(cmd *cobra.Command) {
 
 	cmd.PersistentFlags().StringArrayVar(&podAttributes, pod.Flag, []string{}, "(Optional) Pod-specific attributes in key=value format.")
 
-	cmd.PersistentFlags().BoolVar(&isFullstack, FullstackFlag, false, "(Optional) Configure the CodeModule to be fullstack.")
+	cmd.PersistentFlags().BoolVar(&isFullstack, IsFullstackFlag, false, "(Optional) Configure the CodeModule to be fullstack.")
 
-	cmd.PersistentFlags().Lookup(FullstackFlag).NoOptDefVal = "false"
+	cmd.PersistentFlags().Lookup(IsFullstackFlag).NoOptDefVal = "false"
 }
 
 func Execute(log logr.Logger, fs afero.Afero, targetDir string) error {

--- a/cmd/configure/cmd.go
+++ b/cmd/configure/cmd.go
@@ -46,6 +46,8 @@ func AddFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringArrayVar(&podAttributes, pod.Flag, []string{}, "(Optional) Pod-specific attributes in key=value format.")
 
 	cmd.PersistentFlags().BoolVar(&isFullstack, FullstackFlag, false, "(Optional) Configure the CodeModule to be fullstack.")
+
+	cmd.PersistentFlags().Lookup(FullstackFlag).NoOptDefVal = "false"
 }
 
 func Execute(log logr.Logger, fs afero.Afero, targetDir string) error {

--- a/cmd/configure/cmd_test.go
+++ b/cmd/configure/cmd_test.go
@@ -22,7 +22,7 @@ import (
 var testLog = zapr.NewLogger(zap.NewExample())
 
 // Only checking the counts of files in the folders, checking exact paths and contents are done in the sub-package tests.
-func TestExecute(t *testing.T) {
+func TestSetupOneAgent(t *testing.T) {
 	targetFolder := "/path/target"
 
 	podAttributes = []string{
@@ -51,10 +51,10 @@ func TestExecute(t *testing.T) {
 		preExecuteTargetCount := countFiles(t, memFs, targetFolder)
 		require.Equal(t, 1, preExecuteTargetCount) // for pmc, you need a source file
 
-		err := Execute(testLog, memFs, targetFolder)
+		err := SetupOneAgent(testLog, memFs, targetFolder)
 		require.NoError(t, err)
 
-		expectedContainerSpecificConfigCount := 7 // endpoint(1) + curl(1) + ca(2) + conf(1) + metadata(2)
+		expectedContainerSpecificConfigCount := 4 // curl(1) + ca(2) + conf(1)
 
 		for _, name := range containerNames {
 			containerConfigFolder := filepath.Join(configFolder, name)
@@ -76,7 +76,7 @@ func TestExecute(t *testing.T) {
 		configFolder = "/path/config"
 		memFs := afero.Afero{Fs: afero.NewMemMapFs()}
 
-		err := Execute(testLog, memFs, targetFolder)
+		err := SetupOneAgent(testLog, memFs, targetFolder)
 		require.NoError(t, err)
 
 		postExecuteConfigCount := countFiles(t, memFs, configFolder)
@@ -91,7 +91,7 @@ func TestExecute(t *testing.T) {
 		inputFolder = "/path/config"
 		memFs := afero.Afero{Fs: afero.NewMemMapFs()}
 
-		err := Execute(testLog, memFs, targetFolder)
+		err := SetupOneAgent(testLog, memFs, targetFolder)
 		require.NoError(t, err)
 
 		postExecuteConfigCount := countFiles(t, memFs, configFolder)
@@ -100,7 +100,74 @@ func TestExecute(t *testing.T) {
 		postExecuteTargetCount := countFiles(t, memFs, targetFolder)
 		require.Equal(t, 0, postExecuteTargetCount)
 	})
+}
 
+func TestEnrichWithMetadata(t *testing.T) {
+	targetFolder := "/path/target"
+
+	podAttributes = []string{
+		"k8s.pod.name=pod1",
+		"k8s.pod.uid=123",
+		"k8s.namespace.name=default",
+	}
+
+	containerNames := []string{"test-container-name", "other-container-name"}
+	containerAttributes = []string{
+		`{"container_image.registry": "some.reg.io", "container_image.repository": "test-repo", "container_image.tags": "latest", "container_image.digest": "sha256:abcd1234", "k8s.container.name": "test-container-name"}`,
+		`{"container_image.registry": "some.reg.io", "container_image.repository": "test-repo", "container_image.tags": "latest", "container_image.digest": "sha256:abcd1234", "k8s.container.name": "other-container-name"}`,
+	}
+
+	t.Run("success", func(t *testing.T) {
+		inputFolder = "/path/input"
+		configFolder = "/path/config"
+
+		memFs := afero.Afero{Fs: afero.NewMemMapFs()}
+		setupInputFs(t, memFs, inputFolder)
+		setupTargetFs(t, memFs, targetFolder)
+
+		preExecuteConfigCount := countFiles(t, memFs, configFolder)
+		require.Equal(t, 0, preExecuteConfigCount)
+
+		err := EnrichWithMetadata(testLog, memFs)
+		require.NoError(t, err)
+
+		expectedContainerSpecificConfigCount := 3 // endpoint(1) + metadata(2)
+
+		for _, name := range containerNames {
+			containerConfigFolder := filepath.Join(configFolder, name)
+
+			containerSpecificConfigCount := countFiles(t, memFs, containerConfigFolder)
+			require.Equal(t, expectedContainerSpecificConfigCount, containerSpecificConfigCount)
+		}
+
+		expectedPostExecuteConfigCount := len(containerNames) * expectedContainerSpecificConfigCount // len(containers) * container-specific-files
+		postExecuteConfigCount := countFiles(t, memFs, configFolder)
+		require.Equal(t, expectedPostExecuteConfigCount, postExecuteConfigCount)
+	})
+
+	t.Run("no input-directory ==> do nothing", func(t *testing.T) {
+		inputFolder = ""
+		configFolder = "/path/config"
+		memFs := afero.Afero{Fs: afero.NewMemMapFs()}
+
+		err := EnrichWithMetadata(testLog, memFs)
+		require.NoError(t, err)
+
+		postExecuteConfigCount := countFiles(t, memFs, configFolder)
+		require.Equal(t, 0, postExecuteConfigCount)
+	})
+
+	t.Run("no config-directory ==> do nothing", func(t *testing.T) {
+		configFolder = ""
+		inputFolder = "/path/config"
+		memFs := afero.Afero{Fs: afero.NewMemMapFs()}
+
+		err := EnrichWithMetadata(testLog, memFs)
+		require.NoError(t, err)
+
+		postExecuteConfigCount := countFiles(t, memFs, configFolder)
+		require.Equal(t, 0, postExecuteConfigCount)
+	})
 }
 
 func countFiles(t *testing.T, memFs afero.Afero, path string) int {

--- a/hack/testing/helm-sample/values.yaml
+++ b/hack/testing/helm-sample/values.yaml
@@ -11,6 +11,8 @@ args:
   - --target=/mnt/bin
   - --config-directory=/mnt/config
   - --input-directory=/mnt/input
+  - --fullstack
+  - --tenant=test-tenant
   - --attribute=k8s.pod.name=test-pod-name
   - --attribute=k8s.pod.uid=test-pod-uid
   - --attribute=k8s.namespace.name=test-namespace
@@ -20,7 +22,6 @@ args:
   - --attribute=user.defined.1=test-user-defined-1
   - --attribute=user.defined.2=test-user-defined-2
   - --attribute=dt.entity.kubernetes_cluster=test-entity-cluster
-  - --attribute=dt.tenant=test-tenant
   - --attribute=k8s.node.name=test-node-name
   - --attribute-container={"k8s.container.name":"app", "container_image.registry":"gcr.io", "container_image.repository":"testrepo", "container_image.tags":"testtag", "container_image.digest":"testdigest"}
   - --attribute-container={"k8s.container.name":"app2", "container_image.registry":"gcr.io", "container_image.repository":"othertest"}

--- a/hack/testing/helm-sample/values.yaml
+++ b/hack/testing/helm-sample/values.yaml
@@ -20,6 +20,7 @@ args:
   - --attribute=user.defined.1=test-user-defined-1
   - --attribute=user.defined.2=test-user-defined-2
   - --attribute=dt.entity.kubernetes_cluster=test-entity-cluster
+  - --attribute=dt.tenant=test-tenant
   - --attribute=k8s.node.name=test-node-name
   - --attribute-container={"k8s.container.name":"app", "container_image.registry":"gcr.io", "container_image.repository":"testrepo", "container_image.tags":"testtag", "container_image.digest":"testdigest"}
   - --attribute-container={"k8s.container.name":"app2", "container_image.registry":"gcr.io", "container_image.repository":"othertest"}

--- a/pkg/configure/oneagent/conf/conf.go
+++ b/pkg/configure/oneagent/conf/conf.go
@@ -14,8 +14,8 @@ const (
 	ConfigPath = "/oneagent/agent/config/container.conf"
 )
 
-func Configure(log logr.Logger, fs afero.Afero, configDirectory string, containerAttr container.Attributes, podAttr pod.Attributes) error {
-	confContent := fromAttributes(containerAttr, podAttr)
+func Configure(log logr.Logger, fs afero.Afero, configDirectory string, containerAttr container.Attributes, podAttr pod.Attributes, isFullstack bool) error {
+	confContent := fromAttributes(containerAttr, podAttr, isFullstack)
 
 	stringContent, err := confContent.toString()
 	if err != nil {

--- a/pkg/configure/oneagent/conf/conf.go
+++ b/pkg/configure/oneagent/conf/conf.go
@@ -1,6 +1,7 @@
 package conf
 
 import (
+	"errors"
 	"path/filepath"
 
 	"github.com/Dynatrace/dynatrace-bootstrapper/cmd/configure/attributes/container"
@@ -14,8 +15,12 @@ const (
 	ConfigPath = "/oneagent/agent/config/container.conf"
 )
 
-func Configure(log logr.Logger, fs afero.Afero, configDirectory string, containerAttr container.Attributes, podAttr pod.Attributes, isFullstack bool) error {
-	confContent := fromAttributes(containerAttr, podAttr, isFullstack)
+func Configure(log logr.Logger, fs afero.Afero, configDirectory string, containerAttr container.Attributes, podAttr pod.Attributes, tenant string, isFullstack bool) error {
+	if isFullstack && tenant == "" {
+		return errors.New("fullstack mode is set, but no tenant was provided")
+	}
+
+	confContent := fromAttributes(containerAttr, podAttr, tenant, isFullstack)
 
 	stringContent, err := confContent.toString()
 	if err != nil {

--- a/pkg/configure/oneagent/conf/conf.go
+++ b/pkg/configure/oneagent/conf/conf.go
@@ -16,8 +16,14 @@ const (
 )
 
 func Configure(log logr.Logger, fs afero.Afero, configDirectory string, containerAttr container.Attributes, podAttr pod.Attributes, tenant string, isFullstack bool) error {
-	if isFullstack && tenant == "" {
-		return errors.New("fullstack mode is set, but no tenant was provided")
+	log.Info("configuring container.conf", "config-directory", configDirectory)
+
+	if isFullstack {
+		log.Info("fullstack flag detected, configuring accordingly", "tenant", tenant)
+
+		if tenant == "" {
+			return errors.New("fullstack mode is set, but no tenant was provided")
+		}
 	}
 
 	confContent := fromAttributes(containerAttr, podAttr, tenant, isFullstack)

--- a/pkg/configure/oneagent/conf/conf_test.go
+++ b/pkg/configure/oneagent/conf/conf_test.go
@@ -21,10 +21,10 @@ func TestConfigure(t *testing.T) {
 			PodName:       "podname",
 			PodUID:        "poduid",
 			NamespaceName: "namespacename",
-			NodeName: "nodename",
+			NodeName:      "nodename",
 		},
 		ClusterInfo: pod.ClusterInfo{
-			ClusterUID: "clusteruid",
+			ClusterUID:  "clusteruid",
 			DTTenantUID: "tenant",
 		},
 	}
@@ -52,6 +52,7 @@ func TestConfigure(t *testing.T) {
 		require.NoError(t, err)
 
 		missingEntries := []string{}
+
 		for key, value := range expectedMap {
 			if value == "" {
 				assert.NotContains(t, string(content), key)
@@ -63,6 +64,7 @@ func TestConfigure(t *testing.T) {
 
 		expectedMissingEntries := []string{"tenant", "k8s_node_name", "isCloudNativeFullStack"}
 		require.Subset(t, expectedMissingEntries, missingEntries) // incase of isFullstack, the host section is missing from the map
+
 		for _, key := range expectedMissingEntries {
 			assert.NotContains(t, string(content), key)
 		}
@@ -70,7 +72,6 @@ func TestConfigure(t *testing.T) {
 		assert.Contains(t, string(content), "[container]")
 		assert.NotContains(t, string(content), "[host]")
 	})
-
 
 	t.Run("success - fullstack", func(t *testing.T) {
 		fs := afero.Afero{Fs: afero.NewMemMapFs()}

--- a/pkg/configure/oneagent/conf/conf_test.go
+++ b/pkg/configure/oneagent/conf/conf_test.go
@@ -24,8 +24,7 @@ func TestConfigure(t *testing.T) {
 			NodeName:      "nodename",
 		},
 		ClusterInfo: pod.ClusterInfo{
-			ClusterUID:  "clusteruid",
-			DTTenantUID: "tenant",
+			ClusterUID: "clusteruid",
 		},
 	}
 	containerAttr := container.Attributes{
@@ -42,10 +41,10 @@ func TestConfigure(t *testing.T) {
 	t.Run("success - not fullstack", func(t *testing.T) {
 		fs := afero.Afero{Fs: afero.NewMemMapFs()}
 
-		err := Configure(testLog, fs, configDir, containerAttr, podAttr, false)
+		err := Configure(testLog, fs, configDir, containerAttr, podAttr, "", false)
 		require.NoError(t, err)
 
-		expectedMap, err := fromAttributes(containerAttr, podAttr, false).toMap()
+		expectedMap, err := fromAttributes(containerAttr, podAttr, "", false).toMap()
 		require.NoError(t, err)
 
 		content, err := fs.ReadFile(filepath.Join(configDir, ConfigPath))
@@ -75,11 +74,12 @@ func TestConfigure(t *testing.T) {
 
 	t.Run("success - fullstack", func(t *testing.T) {
 		fs := afero.Afero{Fs: afero.NewMemMapFs()}
+		tenant := "test-tenant"
 
-		err := Configure(testLog, fs, configDir, containerAttr, podAttr, true)
+		err := Configure(testLog, fs, configDir, containerAttr, podAttr, tenant, true)
 		require.NoError(t, err)
 
-		expectedMap, err := fromAttributes(containerAttr, podAttr, true).toMap()
+		expectedMap, err := fromAttributes(containerAttr, podAttr, tenant, true).toMap()
 		require.NoError(t, err)
 
 		content, err := fs.ReadFile(filepath.Join(configDir, ConfigPath))
@@ -91,5 +91,12 @@ func TestConfigure(t *testing.T) {
 
 		assert.Contains(t, string(content), "[container]")
 		assert.Contains(t, string(content), "[host]")
+	})
+
+	t.Run("error - fullstack but no tenant", func(t *testing.T) {
+		fs := afero.Afero{Fs: afero.NewMemMapFs()}
+
+		err := Configure(testLog, fs, configDir, containerAttr, podAttr, "", true)
+		require.Error(t, err)
 	})
 }

--- a/pkg/configure/oneagent/conf/conf_test.go
+++ b/pkg/configure/oneagent/conf/conf_test.go
@@ -21,9 +21,11 @@ func TestConfigure(t *testing.T) {
 			PodName:       "podname",
 			PodUID:        "poduid",
 			NamespaceName: "namespacename",
+			NodeName: "nodename",
 		},
 		ClusterInfo: pod.ClusterInfo{
 			ClusterUID: "clusteruid",
+			DTTenantUID: "tenant",
 		},
 	}
 	containerAttr := container.Attributes{
@@ -37,20 +39,56 @@ func TestConfigure(t *testing.T) {
 	}
 	configDir := "path/conf"
 
-	t.Run("success", func(t *testing.T) {
+	t.Run("success - not fullstack", func(t *testing.T) {
 		fs := afero.Afero{Fs: afero.NewMemMapFs()}
 
-		err := Configure(testLog, fs, configDir, containerAttr, podAttr)
+		err := Configure(testLog, fs, configDir, containerAttr, podAttr, false)
 		require.NoError(t, err)
 
-		expectedContent, err := fromAttributes(containerAttr, podAttr).toMap()
+		expectedMap, err := fromAttributes(containerAttr, podAttr, false).toMap()
 		require.NoError(t, err)
 
 		content, err := fs.ReadFile(filepath.Join(configDir, ConfigPath))
 		require.NoError(t, err)
 
-		for key, value := range expectedContent {
+		missingEntries := []string{}
+		for key, value := range expectedMap {
+			if value == "" {
+				assert.NotContains(t, string(content), key)
+				missingEntries = append(missingEntries, key)
+			} else {
+				assert.Contains(t, string(content), key+" "+value)
+			}
+		}
+
+		expectedMissingEntries := []string{"tenant", "k8s_node_name", "isCloudNativeFullStack"}
+		require.Subset(t, expectedMissingEntries, missingEntries) // incase of isFullstack, the host section is missing from the map
+		for _, key := range expectedMissingEntries {
+			assert.NotContains(t, string(content), key)
+		}
+
+		assert.Contains(t, string(content), "[container]")
+		assert.NotContains(t, string(content), "[host]")
+	})
+
+
+	t.Run("success - fullstack", func(t *testing.T) {
+		fs := afero.Afero{Fs: afero.NewMemMapFs()}
+
+		err := Configure(testLog, fs, configDir, containerAttr, podAttr, true)
+		require.NoError(t, err)
+
+		expectedMap, err := fromAttributes(containerAttr, podAttr, true).toMap()
+		require.NoError(t, err)
+
+		content, err := fs.ReadFile(filepath.Join(configDir, ConfigPath))
+		require.NoError(t, err)
+
+		for key, value := range expectedMap {
 			assert.Contains(t, string(content), key+" "+value)
 		}
+
+		assert.Contains(t, string(content), "[container]")
+		assert.Contains(t, string(content), "[host]")
 	})
 }

--- a/pkg/configure/oneagent/conf/content.go
+++ b/pkg/configure/oneagent/conf/content.go
@@ -18,29 +18,29 @@ func (fc fileContent) toMap() (map[string]string, error) {
 }
 
 func (fc fileContent) toString() (string, error) {
-	var confContent strings.Builder
+	var content strings.Builder
 
 	if fc.containerSection != nil {
-		content, err := fc.containerSection.toString()
+		sectionContent, err := fc.containerSection.toString()
 		if err != nil {
 			return "", err
 		}
 
-		confContent.WriteString(content)
-		confContent.WriteString("\n")
+		content.WriteString(sectionContent)
+		content.WriteString("\n")
 	}
 
 	if fc.hostSection != nil {
-		content, err := fc.hostSection.toString()
+		sectionContent, err := fc.hostSection.toString()
 		if err != nil {
 			return "", err
 		}
 
-		confContent.WriteString(content)
-		confContent.WriteString("\n")
+		content.WriteString(sectionContent)
+		content.WriteString("\n")
 	}
 
-	return confContent.String(), nil
+	return content.String(), nil
 }
 
 type containerSection struct {
@@ -59,28 +59,28 @@ func (cs containerSection) toMap() (map[string]string, error) {
 }
 
 func (cs containerSection) toString() (string, error) {
-	var sectionContent strings.Builder
+	var content strings.Builder
 
 	contentMap, err := cs.toMap()
 	if err != nil {
 		return "", err
 	}
 
-	sectionContent.WriteString("[container]")
-	sectionContent.WriteString("\n")
+	content.WriteString("[container]")
+	content.WriteString("\n")
 
 	for key, value := range contentMap {
 		if value == "" {
 			continue
 		}
 
-		sectionContent.WriteString(key)
-		sectionContent.WriteString(" ")
-		sectionContent.WriteString(value)
-		sectionContent.WriteString("\n")
+		content.WriteString(key)
+		content.WriteString(" ")
+		content.WriteString(value)
+		content.WriteString("\n")
 	}
 
-	return sectionContent.String(), nil
+	return content.String(), nil
 }
 
 type hostSection struct {
@@ -93,32 +93,32 @@ func (hs hostSection) toMap() (map[string]string, error) {
 }
 
 func (hs hostSection) toString() (string, error) {
-	var sectionContent strings.Builder
+	var content strings.Builder
 
 	contentMap, err := hs.toMap()
 	if err != nil {
 		return "", err
 	}
 
-	sectionContent.WriteString("[host]")
-	sectionContent.WriteString("\n")
+	content.WriteString("[host]")
+	content.WriteString("\n")
 
 	for key, value := range contentMap {
 		if value == "" {
 			continue
 		}
 
-		sectionContent.WriteString(key)
-		sectionContent.WriteString(" ")
-		sectionContent.WriteString(value)
-		sectionContent.WriteString("\n")
+		content.WriteString(key)
+		content.WriteString(" ")
+		content.WriteString(value)
+		content.WriteString("\n")
 	}
 
-	return sectionContent.String(), nil
+	return content.String(), nil
 }
 
 func fromAttributes(containerAttr container.Attributes, podAttr pod.Attributes, tenant string, isFullStack bool) fileContent {
-	fileContent := fileContent{
+	fc := fileContent{
 		containerSection: &containerSection{
 			PodName:                 podAttr.PodName,
 			PodUID:                  podAttr.PodUID,
@@ -131,12 +131,12 @@ func fromAttributes(containerAttr container.Attributes, podAttr pod.Attributes, 
 	}
 
 	if isFullStack {
-		fileContent.hostSection = &hostSection{
+		fc.hostSection = &hostSection{
 			Tenant:      tenant,
 			IsFullStack: "true",
 		}
-		fileContent.NodeName = podAttr.NodeName
+		fc.NodeName = podAttr.NodeName
 	}
 
-	return fileContent
+	return fc
 }

--- a/pkg/configure/oneagent/conf/content.go
+++ b/pkg/configure/oneagent/conf/content.go
@@ -117,7 +117,7 @@ func (hs hostSection) toString() (string, error) {
 	return sectionContent.String(), nil
 }
 
-func fromAttributes(containerAttr container.Attributes, podAttr pod.Attributes, isFullStack bool) fileContent {
+func fromAttributes(containerAttr container.Attributes, podAttr pod.Attributes, tenant string, isFullStack bool) fileContent {
 	fileContent := fileContent{
 		containerSection: &containerSection{
 			PodName:                 podAttr.PodName,
@@ -132,7 +132,7 @@ func fromAttributes(containerAttr container.Attributes, podAttr pod.Attributes, 
 
 	if isFullStack {
 		fileContent.hostSection = &hostSection{
-			Tenant:      podAttr.DTTenantUID,
+			Tenant:      tenant,
 			IsFullStack: "true",
 		}
 		fileContent.NodeName = podAttr.NodeName

--- a/pkg/configure/oneagent/conf/content.go
+++ b/pkg/configure/oneagent/conf/content.go
@@ -44,14 +44,14 @@ func (fc fileContent) toString() (string, error) {
 }
 
 type containerSection struct {
-	NodeName                string `json:"k8s_node_name"`
-	PodName                 string `json:"k8s_fullpodname"`
-	PodUID                  string `json:"k8s_poduid"`
-	PodNamespace            string `json:"k8s_namespace"`
-	ClusterID               string `json:"k8s_cluster_id"`
-	ContainerName           string `json:"k8s_containername"`
-	DeprecatedContainerName string `json:"containerName"`
-	ImageName               string `json:"imageName"`
+	NodeName                string `json:"k8s_node_name,omitempty"`
+	PodName                 string `json:"k8s_fullpodname,omitempty"`
+	PodUID                  string `json:"k8s_poduid,omitempty"`
+	PodNamespace            string `json:"k8s_namespace,omitempty"`
+	ClusterID               string `json:"k8s_cluster_id,omitempty"`
+	ContainerName           string `json:"k8s_containername,omitempty"`
+	DeprecatedContainerName string `json:"containerName,omitempty"`
+	ImageName               string `json:"imageName,omitempty"`
 }
 
 func (cs containerSection) toMap() (map[string]string, error) {
@@ -84,8 +84,8 @@ func (cs containerSection) toString() (string, error) {
 }
 
 type hostSection struct {
-	Tenant      string `json:"tenant"`
-	IsFullStack string `json:"isCloudNativeFullStack"`
+	Tenant      string `json:"tenant,omitempty"`
+	IsFullStack string `json:"isCloudNativeFullStack,omitempty"`
 }
 
 func (hs hostSection) toMap() (map[string]string, error) {

--- a/pkg/configure/oneagent/conf/content.go
+++ b/pkg/configure/oneagent/conf/content.go
@@ -10,7 +10,7 @@ import (
 
 type fileContent struct {
 	*containerSection `json:",inline,omitempty"`
-	*hostSection `json:",inline,omitempty"`
+	*hostSection      `json:",inline,omitempty"`
 }
 
 func (fc fileContent) toMap() (map[string]string, error) {
@@ -25,6 +25,7 @@ func (fc fileContent) toString() (string, error) {
 		if err != nil {
 			return "", err
 		}
+
 		confContent.WriteString(content)
 		confContent.WriteString("\n")
 	}
@@ -34,6 +35,7 @@ func (fc fileContent) toString() (string, error) {
 		if err != nil {
 			return "", err
 		}
+
 		confContent.WriteString(content)
 		confContent.WriteString("\n")
 	}
@@ -71,6 +73,7 @@ func (cs containerSection) toString() (string, error) {
 		if value == "" {
 			continue
 		}
+
 		sectionContent.WriteString(key)
 		sectionContent.WriteString(" ")
 		sectionContent.WriteString(value)
@@ -82,7 +85,7 @@ func (cs containerSection) toString() (string, error) {
 
 type hostSection struct {
 	Tenant      string `json:"tenant"`
-	IsFullStack string   `json:"isCloudNativeFullStack"`
+	IsFullStack string `json:"isCloudNativeFullStack"`
 }
 
 func (hs hostSection) toMap() (map[string]string, error) {
@@ -104,6 +107,7 @@ func (hs hostSection) toString() (string, error) {
 		if value == "" {
 			continue
 		}
+
 		sectionContent.WriteString(key)
 		sectionContent.WriteString(" ")
 		sectionContent.WriteString(value)
@@ -128,10 +132,10 @@ func fromAttributes(containerAttr container.Attributes, podAttr pod.Attributes, 
 
 	if isFullStack {
 		fileContent.hostSection = &hostSection{
-			Tenant: podAttr.DTTenantUID,
+			Tenant:      podAttr.DTTenantUID,
 			IsFullStack: "true",
 		}
-		fileContent.containerSection.NodeName = podAttr.NodeName
+		fileContent.NodeName = podAttr.NodeName
 	}
 
 	return fileContent

--- a/pkg/configure/oneagent/preload/preload.go
+++ b/pkg/configure/oneagent/preload/preload.go
@@ -14,7 +14,7 @@ const (
 )
 
 func Configure(log logr.Logger, fs afero.Afero, configDir, installPath string) error {
-	log.Info("Configuring ld.so.preload", "config-directory", configDir, "install-path", installPath)
+	log.Info("configuring ld.so.preload", "config-directory", configDir, "install-path", installPath)
 
 	return fsutils.CreateFile(fs, filepath.Join(configDir, ConfigPath), filepath.Join(installPath, LibAgentProcPath))
 }


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-bootstrapper/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

[DAQ-7991](https://dt-rnd.atlassian.net/browse/DAQ-7991)

Adds the `--fullstack` and `--tenant="..."` flag that will influence how we configure the `container.conf`.

If used we add extra values to the `container.conf`:
```
[container]
... // <- old stuff
k8s_node_name <node_name>
[host]
tenant <tenant_UUID>
isCloudNativeFullStack true
```

## How can this be tested?

Use the testing helm chart see that the `container.conf` has the values

[DAQ-7991]: https://dt-rnd.atlassian.net/browse/DAQ-7991?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ