### PR TITLE
Enable `--version` CLI param

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/Dynatrace/dynatrace-bootstrapper/cmd/configure"
@@ -29,6 +30,7 @@ func New(fs afero.Fs) *cobra.Command {
 		RunE:               run(fs),
 		FParseErrWhitelist: cobra.FParseErrWhitelist{UnknownFlags: true},
 		Version:            version.Version,
+		Short:              fmt.Sprintf("%s version %s", version.AppName, version.Version),
 	}
 
 	AddFlags(cmd)

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -28,6 +28,7 @@ func New(fs afero.Fs) *cobra.Command {
 		Use:                Use,
 		RunE:               run(fs),
 		FParseErrWhitelist: cobra.FParseErrWhitelist{UnknownFlags: true},
+		Version:            version.Version,
 	}
 
 	AddFlags(cmd)

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -9,7 +9,7 @@ import (
 var (
 
 	// AppName contains the name of the application
-	AppName = "dynatrace-bootsrapper"
+	AppName = "dynatrace-bootstrapper"
 
 	// Version contains the version of the Bootstrapper. Assigned externally.
 	Version = ""


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-bootstrapper/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description
* `dynatrace-bootstrapper --version` (or `-v`) now works
* `dynatrace-bootstrapper --help` will now also show the current version

Addresses [DAQ-7659](https://dt-rnd.atlassian.net/browse/DAQ-7659)

## How can this be tested?
```sh
go install -ldflags='-X github.com/Dynatrace/dynatrace-bootstrapper/pkg/version.Version=v1.0.4' .
dynatrace-bootstrapper --version # should return "dynatrace-bootstrapper version v1.0.4"
```

[DAQ-7659]: https://dt-rnd.atlassian.net/browse/DAQ-7659?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ