### PR TITLE
Improve local build scripts

### DIFF
--- a/hack/build/build_image.sh
+++ b/hack/build/build_image.sh
@@ -13,6 +13,8 @@ image=${1}
 tag=${2}
 debug=${3:-false}
 
+supported_architectures=("amd64" "arm64")
+
 commit=$(git rev-parse HEAD)
 go_linker_args=$(hack/build/create_go_linker_args.sh "${tag}" "${commit}" "${debug}")
 out_image="${image}:${tag}"
@@ -23,13 +25,8 @@ else
   CONTAINER_CMD=docker
 fi
 
-BOOTSTRAPPER_BUILD_PLATFORM="--platform=linux/amd64"
-if [ -n "${BOOTSTRAPPER_DEV_BUILD_PLATFORM}" ]; then
-  echo "overriding platform to ${BOOTSTRAPPER_DEV_BUILD_PLATFORM}"
-  BOOTSTRAPPER_BUILD_PLATFORM="--platform=${BOOTSTRAPPER_DEV_BUILD_PLATFORM}"
-fi
-
-${CONTAINER_CMD} build "${BOOTSTRAPPER_BUILD_PLATFORM}" . -f ./Dockerfile -t "${out_image}" \
-  --build-arg "GO_LINKER_ARGS=${go_linker_args}" \
-  --label "quay.expires-after=14d"
-
+for architecture in "${supported_architectures[@]}"; do
+  ${CONTAINER_CMD} build "--platform=linux/${architecture}" . -f ./Dockerfile -t "${out_image}-${architecture}" \
+    --build-arg "GO_LINKER_ARGS=${go_linker_args}" \
+    --label "quay.expires-after=14d"
+done

--- a/hack/build/push_image.sh
+++ b/hack/build/push_image.sh
@@ -12,6 +12,7 @@ image=${1}
 tag=${2}
 
 out_image="${image}:${tag}"
+supported_architectures=("amd64" "arm64")
 
 if ! command -v docker 2>/dev/null; then
   CONTAINER_CMD=podman
@@ -19,4 +20,13 @@ else
   CONTAINER_CMD=docker
 fi
 
-${CONTAINER_CMD} push "${out_image}"
+for architecture in "${supported_architectures[@]}"; do
+    ${CONTAINER_CMD} push "${out_image}-${architecture}"
+    images+=("${out_image}-${architecture}")
+done
+
+${CONTAINER_CMD} manifest rm "${out_image}" 2>/dev/null || true
+${CONTAINER_CMD} manifest create "${out_image}" "${images[@]}"
+
+sha256=$(${CONTAINER_CMD} manifest push "${out_image}")
+echo "Image index created locally with digest ${sha256}"


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-bootstrapper/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

Similar to https://github.com/Dynatrace/dynatrace-operator/pull/4927

Just making the local build-scripts "more CI like".

## How can this be tested?

`make build` should:
- build both amd and arm image
- push the images
- create and push a image index for the