### PR TITLE
Fix ruxitagentproc.conf placement + content

### DIFF
--- a/pkg/configure/oneagent/pmc/pmc.go
+++ b/pkg/configure/oneagent/pmc/pmc.go
@@ -13,7 +13,7 @@ const (
 	InputFileName = "ruxitagentproc.json"
 
 	SourceRuxitAgentProcPath      = "agent/conf/ruxitagentproc.conf"
-	DestinationRuxitAgentProcPath = "oneagent/config/ruxitagentproc.conf"
+	DestinationRuxitAgentProcPath = "oneagent/agent/config/ruxitagentproc.conf"
 )
 
 func GetSourceRuxitAgentProcFilePath(targetDir string) string {

--- a/pkg/configure/oneagent/pmc/ruxit/types.go
+++ b/pkg/configure/oneagent/pmc/ruxit/types.go
@@ -90,14 +90,14 @@ func (pm ProcMap) SetupReadonly(installPath string) ProcMap {
 			volume := filepath.VolumeName(value)
 			fmt.Printf("%s", volume)
 
-			if strings.HasPrefix(value, "\"../") {
+			if strings.HasPrefix(entry, "libraryPath") {
 				sanitizedEntry := strings.ReplaceAll(value, "../", "")
 				sanitizedEntry, found := strings.CutPrefix(sanitizedEntry, "\"")
 
 				if found {
-					pm[section][entry] = "\"" + filepath.Join(installPath, sanitizedEntry)
+					pm[section][entry] = "\"" + filepath.Join(installPath, "agent", sanitizedEntry)
 				} else {
-					pm[section][entry] = filepath.Join(installPath, sanitizedEntry)
+					pm[section][entry] = filepath.Join(installPath, "agent", sanitizedEntry)
 				}
 			}
 		}

--- a/pkg/configure/oneagent/pmc/ruxit/types_test.go
+++ b/pkg/configure/oneagent/pmc/ruxit/types_test.go
@@ -204,8 +204,13 @@ func TestSetupReadonly(t *testing.T) {
 			{
 				// overwritten to be absolute path
 				Section: "test",
-				Key:     "keyWithPath",
-				Value:   "\"/absolute/path/relative/path\"",
+				Key:     "libraryPath123",
+				Value:   "\"/absolute/path/agent/relative/path\"",
+			},
+			{
+				Section: "general",
+				Key:     "libraryPathMusl64",
+				Value:   "\"/absolute/path/agent/bin/1.2.3.4-5/linux-musl-x86-64\"",
 			},
 			{
 				// added from override
@@ -229,8 +234,13 @@ func TestSetupReadonly(t *testing.T) {
 			},
 			{
 				Section: "test",
-				Key:     "keyWithPath",
-				Value:   "\"../../relative/path\"",
+				Key:     "libraryPath123",
+				Value:   "\"../relative/path\"",
+			},
+			{
+				Section: "general",
+				Key:     "libraryPathMusl64",
+				Value:   "\"../bin/1.2.3.4-5/linux-musl-x86-64\"",
 			},
 			{
 				// will be removed, as it is not needed in readonly


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-bootstrapper/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

[DAQ-9442](https://dt-rnd.atlassian.net/browse/DAQ-9442)

Moves the configured `ruxitagentproc.conf` to `/var/lib/dynatrace/oneagent/agent/config/ruxitagentproc.conf` 

Updates the libraryPath*entries correctly
- example result: `libraryPath32 "/opt/dynatrace/oneagent-paas/agent/bin/1.318.0.20250605-231149/linux-x86-32"`


## How can this be tested?

You unfortunately can't test it with the CodeModule in the current Dockerfile, as it will not pick up the config.
More details in the linked ticket.


[DAQ-9442]: https://dt-rnd.atlassian.net/browse/DAQ-9442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ