### PR TITLE
Allow 'all' value for the `--technology`

### DIFF
--- a/cmd/move/cmd.go
+++ b/cmd/move/cmd.go
@@ -1,6 +1,8 @@
 package move
 
 import (
+	"strings"
+
 	impl "github.com/Dynatrace/dynatrace-bootstrapper/pkg/move"
 	"github.com/go-logr/logr"
 	"github.com/spf13/afero"
@@ -10,6 +12,8 @@ import (
 const (
 	WorkFolderFlag = "work"
 	TechnologyFlag = "technology"
+
+	AllTechValue = "all" // if set all technologies will be copied, basically reverting back to simple copy
 )
 
 var (
@@ -28,7 +32,7 @@ func AddFlags(cmd *cobra.Command) {
 func Execute(log logr.Logger, fs afero.Afero, from, to string) error {
 	copyFunc := impl.SimpleCopy
 
-	if technology != "" {
+	if technology != "" && strings.TrimSpace(technology) != AllTechValue {
 		copyFunc = impl.CopyByTechnologyWrapper(technology)
 	}
 

--- a/cmd/move/cmd_test.go
+++ b/cmd/move/cmd_test.go
@@ -30,6 +30,8 @@ func TestExecute(t *testing.T) {
 
 		workFolder = workDir
 
+		technology = " " + AllTechValue + " "
+
 		err := Execute(testLog, fs, sourceDir, targetDir)
 		require.NoError(t, err)
 


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-bootstrapper/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

If you say `--technology=all` we do not copy anything.

Now I made it so that this will just revert the behavior to be a simple copy, instead of the filtered via technology copy

## How can this be tested?

Unit tests
+
set `--technology=all` and see that the logs will mention `starting to copy (simple)`