### PR TITLE
Update-bootstrapper-CODEOWNERS-with-aid-ownership

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,21 @@
-*   @Dynatrace/kubernetes-operator
+# Default owners
+*                       @Dynatrace/kubernetes-operator @Dynatrace/team-aid
+
+# k8sinit
+/cmd/k8sinit/           @Dynatrace/kubernetes-operator
+/pkg/configure/         @Dynatrace/kubernetes-operator
+/pkg/move/              @Dynatrace/kubernetes-operator
+
+# serverless
+/main.go                @Dynatrace/team-aid
+/cmd/serverless/        @Dynatrace/team-aid
+
+# Shared packages
+/pkg/deployment/        @Dynatrace/kubernetes-operator @Dynatrace/team-aid
+/pkg/lock/              @Dynatrace/kubernetes-operator @Dynatrace/team-aid
+/pkg/utils/             @Dynatrace/kubernetes-operator @Dynatrace/team-aid
+
+# CI
+/hack/                  @Dynatrace/kubernetes-operator @Dynatrace/team-aid
+/Makefile               @Dynatrace/kubernetes-operator @Dynatrace/team-aid
+/Dockerfile             @Dynatrace/kubernetes-operator @Dynatrace/team-aid

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,15 +7,4 @@
 /pkg/move/              @Dynatrace/kubernetes-operator
 
 # serverless
-/main.go                @Dynatrace/team-aid
 /cmd/serverless/        @Dynatrace/team-aid
-
-# Shared packages
-/pkg/deployment/        @Dynatrace/kubernetes-operator @Dynatrace/team-aid
-/pkg/lock/              @Dynatrace/kubernetes-operator @Dynatrace/team-aid
-/pkg/utils/             @Dynatrace/kubernetes-operator @Dynatrace/team-aid
-
-# CI
-/hack/                  @Dynatrace/kubernetes-operator @Dynatrace/team-aid
-/Makefile               @Dynatrace/kubernetes-operator @Dynatrace/team-aid
-/Dockerfile             @Dynatrace/kubernetes-operator @Dynatrace/team-aid


### PR DESCRIPTION
## Description

[OA-64287](https://dt-rnd.atlassian.net/browse/OA-64287)

Updated owners according to:
- k8sinit → k8s operator
- serverless → AID Team
- utils → Both
- CI → Both


## How can this be tested?
n/a

[OA-64287]: https://dt-rnd.atlassian.net/browse/OA-64287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ