### PR TITLE
Validate installPath before writing to ld.so.preload

### DIFF
--- a/cmd/k8sinit/configure/cmd_test.go
+++ b/cmd/k8sinit/configure/cmd_test.go
@@ -42,6 +42,7 @@ func TestSetupOneAgent(t *testing.T) {
 		baseTempDir := filepath.Join(t.TempDir(), "path")
 		configDir = filepath.Join(baseTempDir, "conf")
 		inputDir = filepath.Join(baseTempDir, "input")
+		installPath = filepath.Join(baseTempDir, "install")
 		targetFolder := filepath.Join(baseTempDir, "target")
 
 		setupInputFs(t, inputDir)

--- a/pkg/configure/oneagent/preload/preload.go
+++ b/pkg/configure/oneagent/preload/preload.go
@@ -1,7 +1,10 @@
 package preload
 
 import (
+	"errors"
+	"fmt"
 	"path/filepath"
+	"strings"
 
 	fsutils "github.com/Dynatrace/dynatrace-bootstrapper/pkg/utils/fs"
 	"github.com/go-logr/logr"
@@ -15,5 +18,25 @@ const (
 func Configure(log logr.Logger, configDir, installPath string) error {
 	log.Info("configuring ld.so.preload", "config-directory", configDir, "install-path", installPath)
 
+	if err := validateInstallPath(installPath); err != nil {
+		return err
+	}
+
 	return fsutils.CreateFile(filepath.Join(configDir, ConfigPath), filepath.Join(installPath, LibAgentProcPath))
+}
+
+func validateInstallPath(installPath string) error {
+	if !filepath.IsAbs(installPath) {
+		return fmt.Errorf("install path must be absolute, got: %s", installPath)
+	}
+
+	if strings.ContainsAny(installPath, "\n\r\t\x00 ,:") {
+		return errors.New("install path must be a single path with no separators or whitespace")
+	}
+
+	if cleaned := filepath.Clean(installPath); cleaned != installPath {
+		return fmt.Errorf("install path must be a clean path, got: %s (expected %s)", installPath, cleaned)
+	}
+
+	return nil
 }

--- a/pkg/configure/oneagent/preload/preload.go
+++ b/pkg/configure/oneagent/preload/preload.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+	"unicode"
 
 	fsutils "github.com/Dynatrace/dynatrace-bootstrapper/pkg/utils/fs"
 	"github.com/go-logr/logr"
@@ -30,8 +31,12 @@ func validateInstallPath(installPath string) error {
 		return fmt.Errorf("install path must be absolute, got: %s", installPath)
 	}
 
-	if strings.ContainsAny(installPath, "\n\r\t\x00 ,:") {
-		return errors.New("install path must be a single path with no separators or whitespace")
+	if strings.ContainsFunc(installPath, unicode.IsSpace) {
+		return errors.New("install path must be a single path with no whitespace")
+	}
+
+	if strings.ContainsAny(installPath, "\x00,:") {
+		return errors.New("install path must be a single path with no separators")
 	}
 
 	if cleaned := filepath.Clean(installPath); cleaned != installPath {

--- a/pkg/configure/oneagent/preload/preload_test.go
+++ b/pkg/configure/oneagent/preload/preload_test.go
@@ -27,4 +27,36 @@ func TestConfigure(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, expectedContent, string(content))
 	})
+
+	t.Run("relative install path is rejected", func(t *testing.T) {
+		err := Configure(testLog, t.TempDir(), "relative/path")
+		require.Error(t, err)
+	})
+
+	t.Run("comma-separated paths are rejected", func(t *testing.T) {
+		baseTempDir := filepath.Join(t.TempDir(), "path")
+		installPath := filepath.Join(baseTempDir, "install")
+		err := Configure(testLog, t.TempDir(), installPath+","+installPath)
+		require.Error(t, err)
+	})
+
+	t.Run("colon-separated paths are rejected", func(t *testing.T) {
+		err := Configure(testLog, t.TempDir(), "/opt/dynatrace:/opt/other")
+		require.Error(t, err)
+	})
+
+	t.Run("install path with newline is rejected", func(t *testing.T) {
+		err := Configure(testLog, t.TempDir(), "/valid/path\n/injected/path")
+		require.Error(t, err)
+	})
+
+	t.Run("install path with null byte is rejected", func(t *testing.T) {
+		err := Configure(testLog, t.TempDir(), "/valid/path\x00extra")
+		require.Error(t, err)
+	})
+
+	t.Run("unclean install path is rejected", func(t *testing.T) {
+		err := Configure(testLog, t.TempDir(), "/valid/../path")
+		require.Error(t, err)
+	})
 }

--- a/pkg/configure/oneagent/preload/preload_test.go
+++ b/pkg/configure/oneagent/preload/preload_test.go
@@ -33,26 +33,25 @@ func TestConfigure(t *testing.T) {
 		require.Error(t, err)
 	})
 
-	t.Run("comma-separated paths are rejected", func(t *testing.T) {
-		baseTempDir := filepath.Join(t.TempDir(), "path")
-		installPath := filepath.Join(baseTempDir, "install")
-		err := Configure(testLog, t.TempDir(), installPath+","+installPath)
-		require.Error(t, err)
+	t.Run("install path with separator is rejected", func(t *testing.T) {
+		for _, path := range []string{
+			"/valid/path,/injected/path",
+			"/valid/path:/other",
+			"/valid/path\x00/other",
+		} {
+			require.Error(t, Configure(testLog, t.TempDir(), path))
+		}
 	})
 
-	t.Run("colon-separated paths are rejected", func(t *testing.T) {
-		err := Configure(testLog, t.TempDir(), "/opt/dynatrace:/opt/other")
-		require.Error(t, err)
-	})
-
-	t.Run("install path with newline is rejected", func(t *testing.T) {
-		err := Configure(testLog, t.TempDir(), "/valid/path\n/injected/path")
-		require.Error(t, err)
-	})
-
-	t.Run("install path with null byte is rejected", func(t *testing.T) {
-		err := Configure(testLog, t.TempDir(), "/valid/path\x00extra")
-		require.Error(t, err)
+	t.Run("install path with whitespace is rejected", func(t *testing.T) {
+		for _, path := range []string{
+			"/valid/path\n/injected/path",
+			"/valid/path\r/other",
+			"/valid/path\t/other",
+			"/valid/path\x00/other",
+		} {
+			require.Error(t, Configure(testLog, t.TempDir(), path))
+		}
 	})
 
 	t.Run("unclean install path is rejected", func(t *testing.T) {
@@ -60,7 +59,7 @@ func TestConfigure(t *testing.T) {
 		require.Error(t, err)
 	})
 
-	// Valid on Linux but rejected: spaces in paths are indistinguishable from
+	// Valid but rejected: spaces in paths are indistinguishable from
 	// whitespace separators in ld.so.preload, so we treat them as invalid.
 	t.Run("path with space is rejected despite being a valid linux path", func(t *testing.T) {
 		err := Configure(testLog, t.TempDir(), "/opt/my agent/dynatrace")

--- a/pkg/configure/oneagent/preload/preload_test.go
+++ b/pkg/configure/oneagent/preload/preload_test.go
@@ -59,4 +59,11 @@ func TestConfigure(t *testing.T) {
 		err := Configure(testLog, t.TempDir(), "/valid/../path")
 		require.Error(t, err)
 	})
+
+	// Valid on Linux but rejected: spaces in paths are indistinguishable from
+	// whitespace separators in ld.so.preload, so we treat them as invalid.
+	t.Run("path with space is rejected despite being a valid linux path", func(t *testing.T) {
+		err := Configure(testLog, t.TempDir(), "/opt/my agent/dynatrace")
+		require.Error(t, err)
+	})
 }


### PR DESCRIPTION
Reject non-absolute, unclean, and multi-path values (control characters, whitespace, commas, colons) to prevent injection of additional entries into ld.so.preload.

<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-bootstrapper/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

https://dt-rnd.atlassian.net/browse/ICP-4033

`install-path` can be a user input, should be validated accordingly.

## How can this be tested?

<!--

Please include some guiding steps on how to test this change during a review.

- What environment is necessary for the change to be noticeable ?
- What needs to be enabled/applied for the change to be noticeable ?

-->