### PR TITLE
Restrict `ruxitagentproc.conf` access

### DIFF
--- a/pkg/configure/oneagent/pmc/create.go
+++ b/pkg/configure/oneagent/pmc/create.go
@@ -2,15 +2,12 @@ package pmc
 
 import (
 	"os"
-	"path/filepath"
 
 	"github.com/Dynatrace/dynatrace-bootstrapper/pkg/configure/oneagent/pmc/ruxit"
+	"github.com/Dynatrace/dynatrace-bootstrapper/pkg/utils/fs"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 )
-
-// ruxitagentproc.conf contains sensitive data, like tenantToken, so we should restrict access as much as we can
-const filePerm = 0600
 
 func Create(log logr.Logger, srcPath, dstPath string, conf ruxit.ProcConf) error {
 	srcFile, err := os.Open(srcPath)
@@ -31,28 +28,5 @@ func Create(log logr.Logger, srcPath, dstPath string, conf ruxit.ProcConf) error
 
 	mergedConf := srcConf.Merge(conf)
 
-	err = os.MkdirAll(filepath.Dir(dstPath), os.ModePerm)
-	if err != nil {
-		log.Info("failed to create destination dir", "path", filepath.Dir(filepath.Dir(dstPath)))
-
-		return err
-	}
-
-	dstFile, err := os.OpenFile(dstPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, filePerm)
-	if err != nil {
-		log.Info("failed to open destination file to write", "path", dstPath)
-
-		return errors.WithStack(err)
-	}
-
-	defer func() { _ = dstFile.Close() }()
-
-	_, err = dstFile.WriteString(mergedConf.ToString())
-	if err != nil {
-		log.Info("failed to write merged config into destination file", "path", dstPath)
-
-		return errors.WithStack(err)
-	}
-
-	return nil
+	return fs.CreateReadOnlyFile(dstPath, mergedConf.ToString())
 }

--- a/pkg/configure/oneagent/pmc/create.go
+++ b/pkg/configure/oneagent/pmc/create.go
@@ -9,6 +9,9 @@ import (
 	"github.com/pkg/errors"
 )
 
+// ruxitagentproc.conf contains sensitive data, like tenantToken, so we should restrict access as much as we can
+const filePerm = 0600
+
 func Create(log logr.Logger, srcPath, dstPath string, conf ruxit.ProcConf) error {
 	srcFile, err := os.Open(srcPath)
 	if err != nil {
@@ -18,13 +21,6 @@ func Create(log logr.Logger, srcPath, dstPath string, conf ruxit.ProcConf) error
 	}
 
 	defer func() { _ = srcFile.Close() }()
-
-	srcInfo, err := srcFile.Stat()
-	if err != nil {
-		log.Info("failed to stat the source file", "path", srcPath)
-
-		return err
-	}
 
 	srcConf, err := ruxit.FromConf(srcFile)
 	if err != nil {
@@ -42,7 +38,7 @@ func Create(log logr.Logger, srcPath, dstPath string, conf ruxit.ProcConf) error
 		return err
 	}
 
-	dstFile, err := os.OpenFile(dstPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, srcInfo.Mode())
+	dstFile, err := os.OpenFile(dstPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, filePerm)
 	if err != nil {
 		log.Info("failed to open destination file to write", "path", dstPath)
 

--- a/pkg/configure/oneagent/pmc/create_test.go
+++ b/pkg/configure/oneagent/pmc/create_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-bootstrapper/pkg/configure/oneagent/pmc/ruxit"
+	"github.com/Dynatrace/dynatrace-bootstrapper/pkg/utils/fs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -31,7 +32,7 @@ func TestCreate(t *testing.T) {
 
 		info, err := os.Stat(dstPath)
 		require.NoError(t, err)
-		assert.Equal(t, os.FileMode(filePerm), info.Mode().Perm())
+		assert.Equal(t, os.FileMode(fs.ReadOnlyFilePerm), info.Mode().Perm())
 	})
 
 	t.Run("merges source and override configs", func(t *testing.T) {

--- a/pkg/configure/oneagent/pmc/create_test.go
+++ b/pkg/configure/oneagent/pmc/create_test.go
@@ -1,0 +1,74 @@
+package pmc
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Dynatrace/dynatrace-bootstrapper/pkg/configure/oneagent/pmc/ruxit"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreate(t *testing.T) {
+	t.Run("destination file has fixed 0600 permissions", func(t *testing.T) {
+		srcDir := t.TempDir()
+		dstDir := t.TempDir()
+
+		srcConf := ruxit.ProcConf{
+			Properties: []ruxit.Property{
+				{Section: "test", Key: "key", Value: "value"},
+			},
+		}
+
+		srcPath := filepath.Join(srcDir, "ruxitagentproc.conf")
+		require.NoError(t, os.WriteFile(srcPath, []byte(srcConf.ToString()), 0644))
+
+		dstPath := filepath.Join(dstDir, "ruxitagentproc.conf")
+
+		err := Create(testLog, srcPath, dstPath, ruxit.ProcConf{})
+		require.NoError(t, err)
+
+		info, err := os.Stat(dstPath)
+		require.NoError(t, err)
+		assert.Equal(t, os.FileMode(filePerm), info.Mode().Perm())
+	})
+
+	t.Run("merges source and override configs", func(t *testing.T) {
+		srcDir := t.TempDir()
+		dstDir := t.TempDir()
+
+		srcConf := ruxit.ProcConf{
+			Properties: []ruxit.Property{
+				{Section: "test", Key: "key", Value: "original"},
+				{Section: "test", Key: "only-in-src", Value: "src"},
+			},
+		}
+
+		override := ruxit.ProcConf{
+			Properties: []ruxit.Property{
+				{Section: "test", Key: "key", Value: "overridden"},
+				{Section: "test", Key: "only-in-override", Value: "override"},
+			},
+		}
+
+		srcPath := filepath.Join(srcDir, "ruxitagentproc.conf")
+		require.NoError(t, os.WriteFile(srcPath, []byte(srcConf.ToString()), 0600))
+
+		dstPath := filepath.Join(dstDir, "ruxitagentproc.conf")
+
+		err := Create(testLog, srcPath, dstPath, override)
+		require.NoError(t, err)
+
+		content, err := os.ReadFile(dstPath)
+		require.NoError(t, err)
+		assert.Equal(t, srcConf.Merge(override).ToString(), string(content))
+	})
+
+	t.Run("missing source file returns error", func(t *testing.T) {
+		dstDir := t.TempDir()
+
+		err := Create(testLog, "/nonexistent/path/ruxitagentproc.conf", filepath.Join(dstDir, "out.conf"), ruxit.ProcConf{})
+		require.Error(t, err)
+	})
+}

--- a/pkg/configure/oneagent/pmc/create_test.go
+++ b/pkg/configure/oneagent/pmc/create_test.go
@@ -22,7 +22,7 @@ func TestCreate(t *testing.T) {
 		}
 
 		srcPath := filepath.Join(srcDir, "ruxitagentproc.conf")
-		require.NoError(t, os.WriteFile(srcPath, []byte(srcConf.ToString()), 0644))
+		require.NoError(t, os.WriteFile(srcPath, []byte(srcConf.ToString()), 0644)) //nolint:gosec
 
 		dstPath := filepath.Join(dstDir, "ruxitagentproc.conf")
 

--- a/pkg/configure/oneagent/pmc/create_test.go
+++ b/pkg/configure/oneagent/pmc/create_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestCreate(t *testing.T) {
-	t.Run("destination file has fixed 0600 permissions", func(t *testing.T) {
+	t.Run("destination file has fixed 0444 permissions", func(t *testing.T) {
 		srcDir := t.TempDir()
 		dstDir := t.TempDir()
 

--- a/pkg/utils/fs/create.go
+++ b/pkg/utils/fs/create.go
@@ -7,7 +7,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-// ruxitagentproc.conf contains
 const ReadOnlyFilePerm = 0444
 
 func CreateFile(path string, content string) error {

--- a/pkg/utils/fs/create.go
+++ b/pkg/utils/fs/create.go
@@ -7,13 +7,25 @@ import (
 	"github.com/pkg/errors"
 )
 
+// ruxitagentproc.conf contains
+const ReadOnlyFilePerm = 0444
+
 func CreateFile(path string, content string) error {
+	return createFileImpl(path, content, os.ModePerm)
+}
+
+func CreateReadOnlyFile(path string, content string) error {
+	return createFileImpl(path, content, ReadOnlyFilePerm)
+}
+
+func createFileImpl(path string, content string, mode os.FileMode) error {
+	// all created folders need to be writable, as the agent may write into them
 	err := os.MkdirAll(filepath.Dir(path), os.ModePerm)
 	if err != nil {
 		return errors.WithStack(err)
 	}
 
-	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, os.ModePerm)
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)
 	if err != nil {
 		return errors.WithStack(err)
 	}


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-bootstrapper/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

https://dt-rnd.atlassian.net/browse/ICP-4299

Just restricts access to `ruxitagentproc.conf`.
- It should only be readable by everything, and not writable

## How can this be tested?

On the fs, you should see:
```
root [ /app ]# ls -la /var/lib/dynatrace/oneagent/agent/config/ruxitagentproc.conf
-r--r--r-- 1 root root 7406 May 11 11:44 /var/lib/dynatrace/oneagent/agent/config/ruxitagentproc.conf
```