### PR TITLE
Make the created ld.so.preload file readonly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN --mount=type=cache,target="/root/.cache/go-build" \
     -o ./build/_output/bin/dynatrace-bootstrapper
 
 # platform is required, otherwise the copy command will copy the wrong architecture files, don't trust GitHub Actions linting warnings
-FROM --platform=$TARGETPLATFORM public.ecr.aws/dynatrace/dynatrace-codemodules:1.329.73.20260123-140641 AS codemodules
+FROM --platform=$TARGETPLATFORM public.ecr.aws/dynatrace/dynatrace-codemodules:1.337.46.20260504-143738 AS codemodules
 
 # copy bootstrapper binary
 COPY --from=build /app/build/_output/bin /opt/dynatrace/oneagent/agent/lib64/

--- a/pkg/configure/oneagent/pmc/create_test.go
+++ b/pkg/configure/oneagent/pmc/create_test.go
@@ -32,7 +32,7 @@ func TestCreate(t *testing.T) {
 
 		info, err := os.Stat(dstPath)
 		require.NoError(t, err)
-		assert.Equal(t, os.FileMode(fs.ReadOnlyFilePerm), info.Mode().Perm())
+		assert.Equal(t, fs.ReadOnlyFilePerm, info.Mode().Perm())
 	})
 
 	t.Run("merges source and override configs", func(t *testing.T) {

--- a/pkg/configure/oneagent/preload/preload.go
+++ b/pkg/configure/oneagent/preload/preload.go
@@ -23,7 +23,7 @@ func Configure(log logr.Logger, configDir, installPath string) error {
 		return err
 	}
 
-	return fsutils.CreateFile(filepath.Join(configDir, ConfigPath), filepath.Join(installPath, LibAgentProcPath))
+	return fsutils.CreateReadOnlyFile(filepath.Join(configDir, ConfigPath), filepath.Join(installPath, LibAgentProcPath))
 }
 
 func validateInstallPath(installPath string) error {

--- a/pkg/configure/oneagent/preload/preload_test.go
+++ b/pkg/configure/oneagent/preload/preload_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/Dynatrace/dynatrace-bootstrapper/pkg/utils/fs"
 	"github.com/go-logr/zapr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -23,9 +24,15 @@ func TestConfigure(t *testing.T) {
 		err := Configure(testLog, configDir, installPath)
 		require.NoError(t, err)
 
-		content, err := os.ReadFile(filepath.Join(configDir, ConfigPath))
+		configPath := filepath.Join(configDir, ConfigPath)
+
+		content, err := os.ReadFile(configPath)
 		require.NoError(t, err)
 		assert.Equal(t, expectedContent, string(content))
+
+		info, err := os.Stat(configPath)
+		require.NoError(t, err)
+		assert.Equal(t, fs.ReadOnlyFilePerm, info.Mode().Perm())
 	})
 
 	t.Run("relative install path is rejected", func(t *testing.T) {

--- a/pkg/utils/fs/create.go
+++ b/pkg/utils/fs/create.go
@@ -7,7 +7,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-const ReadOnlyFilePerm = 0444
+const ReadOnlyFilePerm os.FileMode = 0444
 
 func CreateFile(path string, content string) error {
 	return createFileImpl(path, content, os.ModePerm)

--- a/pkg/utils/fs/create_test.go
+++ b/pkg/utils/fs/create_test.go
@@ -10,10 +10,11 @@ import (
 )
 
 func TestCreateFile(t *testing.T) {
+	const expectedContent = "test\n\ntest"
+
 	t.Run("success, simple file", func(t *testing.T) {
 		tmpDir := t.TempDir()
 
-		expectedContent := "test\n\ntest"
 		fileName := filepath.Join(tmpDir, "test.txt")
 
 		err := CreateFile(fileName, expectedContent)
@@ -26,7 +27,6 @@ func TestCreateFile(t *testing.T) {
 
 	t.Run("success, nested file", func(t *testing.T) {
 		tmpDir := t.TempDir()
-		expectedContent := "test\n\ntest"
 
 		fileName := filepath.Join(tmpDir, "folder", "inside", "test.txt")
 
@@ -57,7 +57,6 @@ func TestCreateReadOnlyFile(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, ReadOnlyFilePerm, info.Mode().Perm())
 	})
-
 	t.Run("success, nested file", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		expectedContent := "test\n\ntest"
@@ -75,5 +74,4 @@ func TestCreateReadOnlyFile(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, ReadOnlyFilePerm, info.Mode().Perm())
 	})
-
 }

--- a/pkg/utils/fs/create_test.go
+++ b/pkg/utils/fs/create_test.go
@@ -40,10 +40,10 @@ func TestCreateFile(t *testing.T) {
 }
 
 func TestCreateReadOnlyFile(t *testing.T) {
+	const expectedContent = "test\n\ntest"
+
 	t.Run("success, simple file", func(t *testing.T) {
 		tmpDir := t.TempDir()
-
-		expectedContent := "test\n\ntest"
 		fileName := filepath.Join(tmpDir, "test.txt")
 
 		err := CreateReadOnlyFile(fileName, expectedContent)
@@ -59,8 +59,6 @@ func TestCreateReadOnlyFile(t *testing.T) {
 	})
 	t.Run("success, nested file", func(t *testing.T) {
 		tmpDir := t.TempDir()
-		expectedContent := "test\n\ntest"
-
 		fileName := filepath.Join(tmpDir, "folder", "inside", "test.txt")
 
 		err := CreateReadOnlyFile(fileName, expectedContent)

--- a/pkg/utils/fs/create_test.go
+++ b/pkg/utils/fs/create_test.go
@@ -38,3 +38,42 @@ func TestCreateFile(t *testing.T) {
 		assert.Equal(t, expectedContent, string(content))
 	})
 }
+
+func TestCreateReadOnlyFile(t *testing.T) {
+	t.Run("success, simple file", func(t *testing.T) {
+		tmpDir := t.TempDir()
+
+		expectedContent := "test\n\ntest"
+		fileName := filepath.Join(tmpDir, "test.txt")
+
+		err := CreateReadOnlyFile(fileName, expectedContent)
+		require.NoError(t, err)
+
+		content, err := os.ReadFile(fileName)
+		require.NoError(t, err)
+		assert.Equal(t, expectedContent, string(content))
+
+		info, err := os.Stat(fileName)
+		require.NoError(t, err)
+		assert.Equal(t, ReadOnlyFilePerm, info.Mode().Perm())
+	})
+
+	t.Run("success, nested file", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		expectedContent := "test\n\ntest"
+
+		fileName := filepath.Join(tmpDir, "folder", "inside", "test.txt")
+
+		err := CreateReadOnlyFile(fileName, expectedContent)
+		require.NoError(t, err)
+
+		content, err := os.ReadFile(fileName)
+		require.NoError(t, err)
+		assert.Equal(t, expectedContent, string(content))
+
+		info, err := os.Stat(fileName)
+		require.NoError(t, err)
+		assert.Equal(t, ReadOnlyFilePerm, info.Mode().Perm())
+	})
+
+}


### PR DESCRIPTION


## Description

https://dt-rnd.atlassian.net/browse/ICP-4036

Makes the `ld.so.preload` file, that is shared between containers, readonly.

## How can this be tested?

On the fs:
```
root [ /app ]# ls -la /etc/ld.so.preload
-r--r--r-- 1 root root 51 May 12 13:45 /etc/ld.so.preload
```

<details><summary>What it used to look like</summary>
<p>

```shell
root [ /app ]# ls -la /etc/ld.so.preload
-rwxrwxrwx 1 1001 1001 59 May 12 13:45 /etc/ld.so.preload
``` 

</p>
</details> 
