### PR TITLE
Add `merge_group` trigger to PR CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,8 @@ on:
   pull_request:
     branches:
       - "*"
+  merge_group:
+    types: [checks_requested]
 
 permissions:
   contents: read
@@ -86,7 +88,7 @@ jobs:
     needs: [prepare]
     permissions:
       packages: write
-    if: github.repository_owner == 'Dynatrace'
+    if: github.repository_owner == 'Dynatrace' && github.event_name != 'merge_group'
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Description
Enables [GitHub's merge queue feature](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue) for our CI pipeline.

Related to https://github.com/Dynatrace/dynatrace-operator/pull/6092 and [DAQ-17845](https://dt-rnd.atlassian.net/browse/DAQ-17845).

[DAQ-17845]: https://dt-rnd.atlassian.net/browse/DAQ-17845?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ