### PR TITLE
Loosen the readonly file permissions to 0644 to handle node restarts

### DIFF
--- a/pkg/configure/oneagent/pmc/create_test.go
+++ b/pkg/configure/oneagent/pmc/create_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestCreate(t *testing.T) {
-	t.Run("destination file has fixed 0444 permissions", func(t *testing.T) {
+	t.Run("destination file has fixed 0644 permissions", func(t *testing.T) {
 		srcDir := t.TempDir()
 		dstDir := t.TempDir()
 
@@ -32,7 +32,7 @@ func TestCreate(t *testing.T) {
 
 		info, err := os.Stat(dstPath)
 		require.NoError(t, err)
-		assert.Equal(t, fs.ReadOnlyFilePerm, info.Mode().Perm())
+		assert.Equal(t, fs.MostlyReadonlyFilePerm, info.Mode().Perm())
 	})
 
 	t.Run("merges source and override configs", func(t *testing.T) {

--- a/pkg/configure/oneagent/preload/preload_test.go
+++ b/pkg/configure/oneagent/preload/preload_test.go
@@ -32,7 +32,7 @@ func TestConfigure(t *testing.T) {
 
 		info, err := os.Stat(configPath)
 		require.NoError(t, err)
-		assert.Equal(t, fs.ReadOnlyFilePerm, info.Mode().Perm())
+		assert.Equal(t, fs.MostlyReadonlyFilePerm, info.Mode().Perm())
 	})
 
 	t.Run("relative install path is rejected", func(t *testing.T) {

--- a/pkg/utils/fs/create.go
+++ b/pkg/utils/fs/create.go
@@ -7,14 +7,16 @@ import (
 	"github.com/pkg/errors"
 )
 
-const ReadOnlyFilePerm os.FileMode = 0444
+// MostlyReadonlyFilePerm is only readonly for everyone but the owner.
+// The owner needs to be able to write it, so we can seamlessly handle node restarts, where the files are not cleaned up.
+const MostlyReadonlyFilePerm os.FileMode = 0644
 
 func CreateFile(path string, content string) error {
 	return createFileImpl(path, content, os.ModePerm)
 }
 
 func CreateReadOnlyFile(path string, content string) error {
-	return createFileImpl(path, content, ReadOnlyFilePerm)
+	return createFileImpl(path, content, MostlyReadonlyFilePerm)
 }
 
 func createFileImpl(path string, content string, mode os.FileMode) error {

--- a/pkg/utils/fs/create_test.go
+++ b/pkg/utils/fs/create_test.go
@@ -55,7 +55,7 @@ func TestCreateReadOnlyFile(t *testing.T) {
 
 		info, err := os.Stat(fileName)
 		require.NoError(t, err)
-		assert.Equal(t, ReadOnlyFilePerm, info.Mode().Perm())
+		assert.Equal(t, MostlyReadonlyFilePerm, info.Mode().Perm())
 	})
 	t.Run("success, nested file", func(t *testing.T) {
 		tmpDir := t.TempDir()
@@ -70,6 +70,6 @@ func TestCreateReadOnlyFile(t *testing.T) {
 
 		info, err := os.Stat(fileName)
 		require.NoError(t, err)
-		assert.Equal(t, ReadOnlyFilePerm, info.Mode().Perm())
+		assert.Equal(t, MostlyReadonlyFilePerm, info.Mode().Perm())
 	})
 }


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-bootstrapper/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

https://dt-rnd.atlassian.net/browse/ICP-5530

Creating truly readonly (0444) files causes problems if the node is restarted.

- During a node restart, the contents of the emptyDirs do not get reset

- After a node restart, the init-containers runs like it was a new new, encountering the previously created (but now readonly) files → permission denied → init-container fails

Mainly an issue if our init-container’s failurePoclicy is **not** silent (by default it is silent)

## How can this be tested?

1. Use the `quay.io/dynatrace/dynatrace-bootstrapper:snapshot-fix-loosen-readonly` as your codeModulesImage
2. Inject into an app (without CSI) (use node-image-pull if not using the snapshot operator)
3. Restart your nodes (**not** re-create)
4. Everything comes up without errors