### PR TITLE
Harden Renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,8 +1,12 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base",
+    "config:best-practices",
   ],
+  osvVulnerabilityAlerts: true,
+  vulnerabilityAlerts: {
+    enabled: true,
+  },
   labels: [
     "dependencies",
   ],
@@ -22,6 +26,7 @@
     "dockerfile",
     "gomod",
     "github-actions",
+    "npm",
   ],
   postUpdateOptions: [
     "gomodTidy",
@@ -80,6 +85,7 @@
       commitMessagePrefix: "Docker:",
       enabled: true,
       allowedVersions: "/^v?[0-9]+[\\.\\-][0-9]+([\\-\\.][0-9]+)*$/",
+      minimumReleaseAge: "3 days",
       automerge: true,
     },
     {
@@ -92,6 +98,7 @@
       commitMessagePrefix: "Go:",
       enabled: true,
       allowedVersions: "/^v?[0-9]+[\\.\\-][0-9]+([\\-\\.][0-9]+)*$/",
+      minimumReleaseAge: "3 days",
       automerge: true,
     },
     {
@@ -115,6 +122,7 @@
       enabled: true,
       automerge: true,
       allowedVersions: "/^v?[0-9]+[\\.\\-][0-9]+([\\-\\.][0-9]+)*$/",
+      minimumReleaseAge: "3 days",
     },
     {
       matchManagers: [
@@ -132,6 +140,7 @@
         "markdownlint-cli",
       ],
       pinVersions: true,
+      minimumReleaseAge: "3 days",
       enabled: true,
       automerge: true,
     },


### PR DESCRIPTION
## Description
* Enforce best practices: https://docs.renovatebot.com/presets-config/#configbest-practices
* Check https://osv.dev for vulnerability alerts
* Set `minimumReleaseAge` to 3 days to reduce the risk of supply-chain attacks
* Enable the `npm` dependency manager
  * There is at least one node dependency in `hack/make/prerequisites.mk`

Follow-up to [DTSEC-22604](https://dt-rnd.atlassian.net/browse/DTSEC-22604) (and related to https://github.com/Dynatrace/dynatrace-operator/pull/6708) 


[DTSEC-22604]: https://dt-rnd.atlassian.net/browse/DTSEC-22604?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ