### PR TITLE
Don't remove log/dataStorageDir entries for ruxitagentproc.conf

### DIFF
--- a/pkg/configure/oneagent/pmc/ruxit/types.go
+++ b/pkg/configure/oneagent/pmc/ruxit/types.go
@@ -64,12 +64,12 @@ func (pc ProcConf) ToMap() ProcMap {
 type ProcMap map[string]map[string]string
 
 var (
-	redundantEntries = map[string][]string{
-		"general": {"logDir", "dataStorageDir"},
-	}
-	additionalEntries = ProcMap{
+	redundantEntries  = map[string][]string{}
+	overriddenEntries = ProcMap{
 		"general": map[string]string{
 			"storage": "\"/var/lib/dynatrace/oneagent\"", // TODO: Make configurable?
+			"logDir": "\"/var/lib/dynatrace/oneagent/log\"",
+			"dataStorageDir": "\"/var/lib/dynatrace/oneagent\"",
 		},
 	}
 )
@@ -104,7 +104,7 @@ func (pm ProcMap) SetupReadonly(installPath string) ProcMap {
 		}
 	}
 
-	return pm.Merge(additionalEntries)
+	return pm.Merge(overriddenEntries)
 }
 
 func (pm ProcMap) ToString() string {

--- a/pkg/configure/oneagent/pmc/ruxit/types_test.go
+++ b/pkg/configure/oneagent/pmc/ruxit/types_test.go
@@ -218,9 +218,21 @@ func TestSetupReadonly(t *testing.T) {
 				Value:   "added-value",
 			},
 			{
-				// added to be work with a readonly CodeModule bin
+				// overridden to work with a readonly CodeModule bin
 				Section: "general",
 				Key:     "storage",
+				Value:   "\"/var/lib/dynatrace/oneagent\"",
+			},
+			{
+				// overridden to work with a readonly CodeModule bin
+				Section: "general",
+				Key:     "logDir",
+				Value:   "\"/var/lib/dynatrace/oneagent/log\"",
+			},
+			{
+				// overridden to work with a readonly CodeModule bin
+				Section: "general",
+				Key:     "dataStorageDir",
 				Value:   "\"/var/lib/dynatrace/oneagent\"",
 			},
 		}
@@ -242,13 +254,13 @@ func TestSetupReadonly(t *testing.T) {
 				Value:   "\"../bin/1.2.3.4-5/linux-musl-x86-64\"",
 			},
 			{
-				// will be removed, as it is not needed in readonly
+				// will be overridden for readonly
 				Section: "general",
 				Key:     "logDir",
 				Value:   "some-path",
 			},
 			{
-				// will be removed, as it is not needed in readonly
+				// will be overridden for readonly
 				Section: "general",
 				Key:     "dataStorageDir",
 				Value:   "some-path",


### PR DESCRIPTION
The process agent doesn't handle it as expected, so they need to be overwritten to work in a readonly injection.

<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-bootstrapper/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description

https://dt-rnd.atlassian.net/browse/ICP-6460

Not setting `logDir` and `dataStorageDir` causes the process agent not being able to log. We should add it back.

## How can this be tested?

0. Use `codeModulesImage: ghcr.io/dynatrace/dynatrace-bootstrapper:snapshot-fix-missing-ruxit-entries` in your DK
1. Add the following envs to your to-be-injected apps
```yaml
          - name: DT_LOGLEVEL_PROC
            value: pgid=debug
          - name: DT_LOGCON_PROC
            value: stdout
```

2. Exec into the injected app, and look for a file like:
```
cat /var/lib/dynatrace/oneagent/log/process/ruxitagentproc_2026-06-24_0.log
```

Also can check the contents of `cat /var/lib/dynatrace/oneagent/agent/config/ruxitagentproc.conf`