### PR TITLE
Remove control characters from PMC properties

### DIFF
--- a/pkg/configure/oneagent/pmc/ruxit/types.go
+++ b/pkg/configure/oneagent/pmc/ruxit/types.go
@@ -107,17 +107,24 @@ func (pm ProcMap) SetupReadonly(installPath string) ProcMap {
 	return pm.Merge(overriddenEntries)
 }
 
+var controlCharReplacer = strings.NewReplacer("\n", "", "\t", "", "\r", "", "\x00", "")
+
+// stripControlChars removes control characters that could be used to inject malicious INI sections/keys into the PMC
+func stripControlChars(s string) string {
+	return controlCharReplacer.Replace(s)
+}
+
 func (pm ProcMap) ToString() string {
 	var content strings.Builder
 
 	for _, section := range slices.Sorted(maps.Keys(pm)) {
-		_, _ = content.WriteString("[" + section + "]")
+		_, _ = content.WriteString("[" + stripControlChars(section) + "]")
 		_, _ = content.WriteString("\n")
 
 		for _, prop := range slices.Sorted(maps.Keys(pm[section])) {
-			_, _ = content.WriteString(prop)
+			_, _ = content.WriteString(stripControlChars(prop))
 			_, _ = content.WriteString(" ")
-			_, _ = content.WriteString(pm[section][prop])
+			_, _ = content.WriteString(stripControlChars(pm[section][prop]))
 			_, _ = content.WriteString("\n")
 		}
 

--- a/pkg/configure/oneagent/pmc/ruxit/types_test.go
+++ b/pkg/configure/oneagent/pmc/ruxit/types_test.go
@@ -190,6 +190,59 @@ func TestMerge(t *testing.T) {
 	})
 }
 
+func TestStripControlChars(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		out  string
+	}{
+		{name: "empty string => unchanged", in: "", out: ""},
+		{name: "clean string => unchanged", in: "foo=bar", out: "foo=bar"},
+		{name: "regular whitespace => kept", in: "foo  bar", out: "foo  bar"},
+		{name: "newline => stripped", in: "foo\nbar", out: "foobar"},
+		{name: "tab => stripped", in: "foo\tbar", out: "foobar"},
+		{name: "carriage return => stripped", in: "foo\rbar", out: "foobar"},
+		{name: "null byte => stripped", in: "foo\x00bar", out: "foobar"},
+		{name: "multiple control chars at once => all stripped", in: "\nfoo\t\rbar\x00", out: "foobar"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.out, stripControlChars(tt.in))
+		})
+	}
+}
+
+func TestToStringStripsControlChars(t *testing.T) {
+	t.Run("newline injected in property value => no INI section injected", func(t *testing.T) {
+		props := []Property{
+			{
+				Section: "general",
+				Key:     "containerInjectionRules",
+				Value:   "x\n[illegal]\nbooooooom\n[general]\nx",
+			},
+		}
+
+		rawString := ProcConf{Properties: props}.ToString()
+
+		for line := range strings.SplitSeq(rawString, "\n") {
+			assert.NotEqual(t, "[illegal]", line, "injected value must not create a new INI section")
+		}
+
+		assert.Equal(t, 1, strings.Count(rawString, "booooooom"))
+	})
+
+	t.Run("control chars in section, key and value => stripped from rendered output", func(t *testing.T) {
+		props := []Property{
+			{Section: "sec\ntion", Key: "k\ney", Value: "v\nalue"},
+		}
+
+		rawString := ProcConf{Properties: props}.ToString()
+
+		assert.Equal(t, "[section]\nkey value\n\n", rawString)
+	})
+}
+
 func TestSetupReadonly(t *testing.T) {
 	t.Run("do adjustments according to installPath", func(t *testing.T) {
 		installPath := "/absolute/path"


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://github.com/Dynatrace/dynatrace-operator/blob/main/CONTRIBUTING.md

2. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

3. Be sure to allow edits from maintainers, so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

## Description
Under certain circumstances, tenant settings values accept newlines, which are passed to the bootstrapper config, then written to `ruxitagentproc.conf`.
This is problematic because control characters like newlines could let property values inject additional INI sections.

Relevant ticket: ICP-6290.

<!--

Please include the following:
- The motivation for the change
    - Link to the Github issue or Jira ticket, if exists.
- The summary of the change

-->

## How can this be tested?
Unit tests