### PR TITLE
Remove control characters from container and metadata enrichment configs

### DIFF
--- a/pkg/configure/enrichment/metadata/content.go
+++ b/pkg/configure/enrichment/metadata/content.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/Dynatrace/dynatrace-bootstrapper/cmd/k8sinit/configure/attributes/container"
 	"github.com/Dynatrace/dynatrace-bootstrapper/cmd/k8sinit/configure/attributes/pod"
+	"github.com/Dynatrace/dynatrace-bootstrapper/pkg/utils/sanitize"
 	"github.com/Dynatrace/dynatrace-bootstrapper/pkg/utils/structs"
 	"github.com/pkg/errors"
 )
@@ -58,9 +59,9 @@ func (c fileContent) toProperties() (string, error) {
 	}
 
 	for key, value := range contentMap {
-		_, _ = confContent.WriteString(key)
+		_, _ = confContent.WriteString(sanitize.StripControlChars(key))
 		_, _ = confContent.WriteString("=")
-		_, _ = confContent.WriteString(value)
+		_, _ = confContent.WriteString(sanitize.StripControlChars(value))
 		_, _ = confContent.WriteString("\n")
 	}
 

--- a/pkg/configure/enrichment/metadata/metadata_test.go
+++ b/pkg/configure/enrichment/metadata/metadata_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-bootstrapper/cmd/k8sinit/configure/attributes/container"
@@ -70,5 +71,27 @@ func TestConfigure(t *testing.T) {
 		for key, value := range expectedContent {
 			assert.Contains(t, string(propsContent), key+"="+value)
 		}
+	})
+
+	t.Run("newline injected in user-defined annotation => no property injected", func(t *testing.T) {
+		baseTempDir := filepath.Join(t.TempDir(), "path")
+		configDir := filepath.Join(baseTempDir, "config")
+
+		cursedPodAttr := podAttr
+		cursedPodAttr.UserDefined = map[string]string{
+			"beep": "boop\ncursed.key=cursed-value",
+		}
+
+		err := Configure(testLog, configDir, cursedPodAttr, containerAttr, alwaysEnableDeprecatedAttributes)
+		require.NoError(t, err)
+
+		propsContent, err := os.ReadFile(filepath.Join(configDir, PropertiesFilePath))
+		require.NoError(t, err)
+
+		for line := range strings.SplitSeq(string(propsContent), "\n") {
+			assert.NotEqual(t, "cursed.key=cursed-value", line, "properties must not be sneaked in via control characters")
+		}
+
+		assert.Contains(t, string(propsContent), "beep=boopcursed.key=cursed-value")
 	})
 }

--- a/pkg/configure/oneagent/conf/conf_test.go
+++ b/pkg/configure/oneagent/conf/conf_test.go
@@ -3,6 +3,7 @@ package conf
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/Dynatrace/dynatrace-bootstrapper/cmd/k8sinit/configure/attributes/container"
@@ -101,5 +102,27 @@ func TestConfigure(t *testing.T) {
 
 		err := Configure(testLog, configDir, containerAttr, podAttr, "", true)
 		require.Error(t, err)
+	})
+
+	t.Run("newline injected in attribute => no new section created", func(t *testing.T) {
+		baseTempDir := filepath.Join(t.TempDir(), "path")
+		configDir := filepath.Join(baseTempDir, "config")
+
+		cursedPodAttr := podAttr
+		cursedPodAttr.PodName = "podname\n[host]\ntenant cursed-tenant\nisCloudNativeFullStack lol"
+
+		err := Configure(testLog, configDir, containerAttr, cursedPodAttr, "", false)
+		require.NoError(t, err)
+
+		content, err := os.ReadFile(filepath.Join(configDir, ConfigPath))
+		require.NoError(t, err)
+
+		for line := range strings.SplitSeq(string(content), "\n") {
+			assert.NotEqual(t, "[host]", line, "injected value must not create a new INI section")
+			assert.NotEqual(t, "tenant cursed-tenant", line, "injected value must not create a new INI entry")
+		}
+
+		assert.Equal(t, 1, strings.Count(string(content), "[container]"))
+		assert.Contains(t, string(content), "k8s_fullpodname podname[host]tenant cursed-tenantisCloudNativeFullStack lol")
 	})
 }

--- a/pkg/configure/oneagent/conf/content.go
+++ b/pkg/configure/oneagent/conf/content.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/Dynatrace/dynatrace-bootstrapper/cmd/k8sinit/configure/attributes/container"
 	"github.com/Dynatrace/dynatrace-bootstrapper/cmd/k8sinit/configure/attributes/pod"
+	"github.com/Dynatrace/dynatrace-bootstrapper/pkg/utils/sanitize"
 	"github.com/Dynatrace/dynatrace-bootstrapper/pkg/utils/structs"
 )
 
@@ -74,9 +75,9 @@ func (cs containerSection) toString() (string, error) {
 			continue
 		}
 
-		_, _ = content.WriteString(key)
+		_, _ = content.WriteString(sanitize.StripControlChars(key))
 		_, _ = content.WriteString(" ")
-		_, _ = content.WriteString(value)
+		_, _ = content.WriteString(sanitize.StripControlChars(value))
 		_, _ = content.WriteString("\n")
 	}
 
@@ -108,9 +109,9 @@ func (hs hostSection) toString() (string, error) {
 			continue
 		}
 
-		_, _ = content.WriteString(key)
+		_, _ = content.WriteString(sanitize.StripControlChars(key))
 		_, _ = content.WriteString(" ")
-		_, _ = content.WriteString(value)
+		_, _ = content.WriteString(sanitize.StripControlChars(value))
 		_, _ = content.WriteString("\n")
 	}
 

--- a/pkg/configure/oneagent/pmc/ruxit/types.go
+++ b/pkg/configure/oneagent/pmc/ruxit/types.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+
+	"github.com/Dynatrace/dynatrace-bootstrapper/pkg/utils/sanitize"
 )
 
 // ProcConf represents the response of the /deployment/installer/agent/processmoduleconfig endpoint from the Dynatrace Environment(v1) API.
@@ -67,8 +69,8 @@ var (
 	redundantEntries  = map[string][]string{}
 	overriddenEntries = ProcMap{
 		"general": map[string]string{
-			"storage": "\"/var/lib/dynatrace/oneagent\"", // TODO: Make configurable?
-			"logDir": "\"/var/lib/dynatrace/oneagent/log\"",
+			"storage":        "\"/var/lib/dynatrace/oneagent\"", // TODO: Make configurable?
+			"logDir":         "\"/var/lib/dynatrace/oneagent/log\"",
 			"dataStorageDir": "\"/var/lib/dynatrace/oneagent\"",
 		},
 	}
@@ -107,24 +109,17 @@ func (pm ProcMap) SetupReadonly(installPath string) ProcMap {
 	return pm.Merge(overriddenEntries)
 }
 
-var controlCharReplacer = strings.NewReplacer("\n", "", "\t", "", "\r", "", "\x00", "")
-
-// stripControlChars removes control characters that could be used to inject malicious INI sections/keys into the PMC
-func stripControlChars(s string) string {
-	return controlCharReplacer.Replace(s)
-}
-
 func (pm ProcMap) ToString() string {
 	var content strings.Builder
 
 	for _, section := range slices.Sorted(maps.Keys(pm)) {
-		_, _ = content.WriteString("[" + stripControlChars(section) + "]")
+		_, _ = content.WriteString("[" + sanitize.StripControlChars(section) + "]")
 		_, _ = content.WriteString("\n")
 
 		for _, prop := range slices.Sorted(maps.Keys(pm[section])) {
-			_, _ = content.WriteString(stripControlChars(prop))
+			_, _ = content.WriteString(sanitize.StripControlChars(prop))
 			_, _ = content.WriteString(" ")
-			_, _ = content.WriteString(stripControlChars(pm[section][prop]))
+			_, _ = content.WriteString(sanitize.StripControlChars(pm[section][prop]))
 			_, _ = content.WriteString("\n")
 		}
 

--- a/pkg/configure/oneagent/pmc/ruxit/types_test.go
+++ b/pkg/configure/oneagent/pmc/ruxit/types_test.go
@@ -190,29 +190,6 @@ func TestMerge(t *testing.T) {
 	})
 }
 
-func TestStripControlChars(t *testing.T) {
-	tests := []struct {
-		name string
-		in   string
-		out  string
-	}{
-		{name: "empty string => unchanged", in: "", out: ""},
-		{name: "clean string => unchanged", in: "foo=bar", out: "foo=bar"},
-		{name: "regular whitespace => kept", in: "foo  bar", out: "foo  bar"},
-		{name: "newline => stripped", in: "foo\nbar", out: "foobar"},
-		{name: "tab => stripped", in: "foo\tbar", out: "foobar"},
-		{name: "carriage return => stripped", in: "foo\rbar", out: "foobar"},
-		{name: "null byte => stripped", in: "foo\x00bar", out: "foobar"},
-		{name: "multiple control chars at once => all stripped", in: "\nfoo\t\rbar\x00", out: "foobar"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.out, stripControlChars(tt.in))
-		})
-	}
-}
-
 func TestToStringStripsControlChars(t *testing.T) {
 	t.Run("newline injected in property value => no INI section injected", func(t *testing.T) {
 		props := []Property{

--- a/pkg/utils/sanitize/sanitize.go
+++ b/pkg/utils/sanitize/sanitize.go
@@ -1,0 +1,11 @@
+package sanitize
+
+import "strings"
+
+var controlCharReplacer = strings.NewReplacer("\n", "", "\t", "", "\r", "", "\x00", "")
+
+// StripControlChars removes control characters (newline, carriage return, tab, null) that
+// could be used to inject forged directives or entries into INI/properties files.
+func StripControlChars(s string) string {
+	return controlCharReplacer.Replace(s)
+}

--- a/pkg/utils/sanitize/sanitize_test.go
+++ b/pkg/utils/sanitize/sanitize_test.go
@@ -1,0 +1,30 @@
+package sanitize
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStripControlChars(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		out  string
+	}{
+		{name: "empty string => unchanged", in: "", out: ""},
+		{name: "clean string => unchanged", in: "foo=bar", out: "foo=bar"},
+		{name: "regular whitespace => kept", in: "foo  bar", out: "foo  bar"},
+		{name: "newline => stripped", in: "foo\nbar", out: "foobar"},
+		{name: "tab => stripped", in: "foo\tbar", out: "foobar"},
+		{name: "carriage return => stripped", in: "foo\rbar", out: "foobar"},
+		{name: "null byte => stripped", in: "foo\x00bar", out: "foobar"},
+		{name: "multiple control chars at once => all stripped", in: "\nfoo\t\rbar\x00", out: "foobar"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.out, StripControlChars(tt.in))
+		})
+	}
+}


### PR DESCRIPTION
## Description
Under certain circumstances, additional sections or entries can be injected into container or metadata enrichment configs. This is because control characters aren't removed from property values. This PR is a follow-up to #194, where control characters were removed from PMC props.

Addresses ICP-8387.

## How can this be tested?
Run this script (from the bootstrapper codebase) twice (with and without my PR applied), and compare the results:

```bash
#!/usr/bin/env bash

set -euo pipefail

TEST_DIR="$(mktemp -d)"
echo "Test dir: ${TEST_DIR}"

BOOTSTRAPPER="$TEST_DIR/bootstrapper"
go build -o "$BOOTSTRAPPER" .

mkdir -p "$TEST_DIR"/{src/agent/bin/1.0,target,input,config}
printf '1.0' > "$TEST_DIR/src/agent/installer.version"

CURSED_PAYLOAD=$'prod\n[host]\ntenant SUPER-MALICIOUS-TENANT\nisCloudNativeFullStack lol'

"$BOOTSTRAPPER" k8s-init \
  --source "$TEST_DIR/src" --target "$TEST_DIR/target" \
  --input-directory "$TEST_DIR/input" --config-directory "$TEST_DIR/config" \
  --fullstack --tenant "actually-legit-tenant" \
  --attribute-container='{"k8s.container.name": "some-app"}' \
  --attribute="k8s.pod.name=some-pod" \
  --attribute="k8s.namespace.name=$CURSED_PAYLOAD" &>/dev/null

CONF="$TEST_DIR/config/some-app/oneagent/agent/config/container.conf"
echo "===== container.conf ====="; cat "$CONF"; echo "=========================="

if grep -q '^tenant SUPER-MALICIOUS-TENANT$' "$CONF"; then
  echo "Result: Vulnerable"; exit 2
else
  echo "Result: Fixed"; exit 0
fi
```